### PR TITLE
added "heroku run rake"; added rake db:migrate sample output

### DIFF
--- a/cases/installfest/create_and_deploy_a_rails_app.step
+++ b/cases/installfest/create_and_deploy_a_rails_app.step
@@ -1,4 +1,3 @@
-
 step "Change to your home directory" do
   option "Windows" do
     console "cd c:\\Sites"
@@ -176,9 +175,19 @@ To git@heroku.com:floating-winter-18.git
 
     note "[What to do if git seems stuck](what_to_do_if_git_seems_stuck)"
 
-    console "heroku rake db:migrate"
+    console "heroku run rake db:migrate"
 
-    todo "expected output of heroku rake db:migrate"
+    result <<-OUTPUT
+Running rake db:migrate attached to terminal... up, run.1
+Migrating to CreateUsers (20111204065949)
+==  CreateUsers: migrating ====================================================
+-- create_table(:users)
+   -> 0.0122s
+==  CreateUsers: migrated (0.0123s) ===========================================
+    OUTPUT
+
+    note "The long number after CreateUsers is a timestamp. Yours will be different!"
+    
   end
 
   step "Visit your new application" do


### PR DESCRIPTION
- changed `heroku rake db:migrate` to `heroku run rake db:migrate`
  - http://devcenter.heroku.com/articles/rake says that if you're on bamboo, you should still use `heroku rake db:migrate`, but it doesn't work for me (`! Internal server error`) when I did it just now (despite heroku info showing that my test app is on bamboo).
  - http://devcenter.heroku.com/articles/cedar#differences_between_bamboo_and_cedar (under "one-off processes...") has more on `run` for cedar. I tried it for my bamboo app, and was able to migrate.
- added rake db:migrate sample output
  - with a note that says the timestamp will be different, so people don't worry
