### PR TITLE
Add before filter to cache pages for an hour.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -58,6 +58,10 @@ class InstallFest < Sinatra::Application
     end
   end
 
+  before do
+    expires 3600, :public
+  end
+
   get '/favicon.ico' do
     halt 404
   end


### PR DESCRIPTION
This commit uses Sinatra's `cache_control` helper in a before filter to add caching via Heroku's Varnish. It will only work on the Bamboo stack but that's likely what this app will use for the immediate future.

This probably won't do _much_ for load times but it will certainly assist with server responsiveness druing workshops. What's more, there's no reason _not_ to cache since the caches are cleared on every deploy and between deploys the content is static.

There is a working mirror of the installfest app with this commit applied at http://sammich-installfest.heroku.com.

The caching can be observed using Faraday with the following:

``` ruby
require "faraday"
print_method = begin
                 require "awesome_print"
                 :ap
               rescue LoadError
                 require "pp"
                 :pp
               end

url = "http://installfest.railsbridge.org/installfest/installfest"
cached_url = "http://sammich-installfest.heroku.com/installfest/installfest"

installfest = Faraday::Connection.new url
cached_installfest = Faraday::Connection.new cached_url

puts "# Hitting #{url}, observe no Cache-Control header."
send(print_method, installfest.get.headers)

puts "\n", "# Hitting #{cached_url}, observe the public Cache-Control header."
send(print_method, cached_installfest.get.headers)
```

which yields

``` ruby
# Hitting http://installfest.railsbridge.org/installfest/installfest
# observe no Cache-Control header.
{
               "server" => "nginx/0.7.67",
                 "date" => "Tue, 27 Dec 2011 18:36:39 GMT",
         "content-type" => "text/html;charset=utf-8",
    "transfer-encoding" => "chunked",
           "connection" => "close",
      "x-frame-options" => "sameorigin",
     "x-xss-protection" => "1; mode=block",
            "x-varnish" => "1237521881",
                  "age" => "0",
                  "via" => "1.1 varnish"
}

# Hitting http://sammich-installfest.heroku.com/installfest/installfest
# observe the public Cache-Control header.
{
               "server" => "nginx/0.7.67",
                 "date" => "Tue, 27 Dec 2011 18:36:40 GMT",
         "content-type" => "text/html;charset=utf-8",
    "transfer-encoding" => "chunked",
           "connection" => "close",
      "x-frame-options" => "sameorigin",
     "x-xss-protection" => "1; mode=block",
        "cache-control" => "public, max-age=3600",
              "expires" => "Tue, 27 Dec 2011 19:32:55 GMT",
            "x-varnish" => "526466651 526390325",
                  "age" => "225",
                  "via" => "1.1 varnish"
}
```
