### PR TITLE
Fix trailing whitespace in Ruby code.

### DIFF
--- a/lib/doc_page.rb
+++ b/lib/doc_page.rb
@@ -34,7 +34,7 @@ class DocPage < Erector::Widgets::Page
   # external :style,  <<-CSS
   # @import url(http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700);
   # CSS
-  
+
   # but this is to load the Open Sans font when we might be offline
   external :style,  <<-CSS
   @import url(/font/opensans.css);
@@ -50,7 +50,7 @@ class DocPage < Erector::Widgets::Page
     padding: 0;
     margin: 0;
   }
-    
+
   h1 {
     font-size: 2em;
     -webkit-margin-before: 0;
@@ -130,7 +130,7 @@ class DocPage < Erector::Widgets::Page
     float: right;
     margin: 2px;
   }
-  
+
   img {
     border: 1px solid #aaa;
     margin: auto;
@@ -145,7 +145,7 @@ class DocPage < Erector::Widgets::Page
       a "[#{@name}]", :class => "top_link", :href => @href, :onclick => @onclick
     end
   end
-  
+
   def top_links
     file_name = @doc_path.split('/').last
     [
@@ -154,7 +154,7 @@ class DocPage < Erector::Widgets::Page
       TopLink.new(:name => "git", :href => "https://github.com/railsbridge/installfest/blob/master/sites/#{@site_name}/#{file_name}"),
     ]
   end
-  
+
   def head_content
     super
     script :src => "/jquery-1.6.1.js"
@@ -184,7 +184,7 @@ class DocPage < Erector::Widgets::Page
             text @back.split('#').first #todo: titleize etc, use real doc object
           end
         }
-      end      
+      end
     }
 
     div(:class=>:bottom) {

--- a/lib/github_flavored_markdown.rb
+++ b/lib/github_flavored_markdown.rb
@@ -27,7 +27,6 @@ module GithubFlavoredMarkdown
     # make bare URLs into hot links
     text.gsub!(%r{(?<![\(:<])((https?|mailto)://\S*)}, '<\\1>')
 
-
     text
   end
 

--- a/lib/media_wiki.rb
+++ b/lib/media_wiki.rb
@@ -5,12 +5,12 @@ module MediaWiki
     gsub(/^\* /, "\n* ").
     gsub(/^\*\* /, " * ").
     gsub(/^\*\*\* /, "  * ").
-    
+
     # square-bullet lists (turn into regular bullets)
     gsub(/^\# /, "\n* ").
     gsub(/^\#\# /, " * ").
     gsub(/^\#\#\# /, "  * ").
-    
+
     # headings
     gsub(/^==== ?(.*)( *====)\s*$/, "### \\1").
     gsub(/^=== ?(.*)( *===)\s*$/, "## \\1").
@@ -19,14 +19,14 @@ module MediaWiki
 
     # plain links
     gsub(%r{(?<![\(:])((https?|mailto)://\S*)}, '<\\1>').
-    
+
     # # [name url] links
     # gsub(/(?<!\!\[)\[([^\] ]*)( [^\]]*)?\]/){
     #   url = $1
     #   name = $2 || url
     #   "[#{name}](#{url})"
     # }.
-    
+
     # [[]] links
     gsub(/\[\[([^\]]*)\]\]/) {|match|
       match = $1
@@ -37,13 +37,13 @@ module MediaWiki
         else
           "#{path}"
         end
-        "![#{path.split('/').last}](#{url})"       
+        "![#{path.split('/').last}](#{url})"
       else
         title = match.gsub(/[\(\)]/, '')
         page = title.downcase.gsub(/\W+/, '_').strip
         "[#{title}](#{page})"
       end
-    }.      
+    }.
     gsub(/'''(.+)'''/, '**\\1**').
     gsub(/''(.+)''/, '*\\1*').
     # tables

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -4,7 +4,7 @@ class Step < Erector::Widget
   include GithubFlavoredMarkdown
 
   external :style, <<-CSS
-  
+
 .step h1>span.prefix {
   color: blue;
 }
@@ -83,7 +83,7 @@ div.back:before {
 
   needs :src
   needs :doc_path
-  
+
   def initialize options
     super
     @step_stack = []
@@ -93,7 +93,7 @@ div.back:before {
     @step_stack << 0 if @step_stack.empty?
     @step_stack[-1] = @step_stack.last + 1
   end
-  
+
   def as_title name
     name.to_s.split('_').map{|s| s.capitalize}.join(' ')
   end
@@ -107,12 +107,12 @@ div.back:before {
     nested_steps.pop if nested_steps.last == 0
     nested_steps.join("-")
   end
-  
+
   # todo: move into proper Doc class
   def page_name
     @doc_path.split('/').last.split('.').first
   end
-  
+
   ## steps
 
   def steps
@@ -206,7 +206,7 @@ div.back:before {
       end
     end
   end
-  
+
   def goals
     div :class => "goals" do
       h1 "Goals"
@@ -215,7 +215,7 @@ div.back:before {
       end
     end
   end
-  
+
   alias_method :goal, :li
 
   ## notes
@@ -223,7 +223,7 @@ div.back:before {
   def note text
     p raw(md2html text)
   end
-  
+
   def important text = nil
     div :class=>"important" do
       rawtext(md2html text) unless text.nil?
@@ -266,7 +266,7 @@ div.back:before {
   def content
     eval @src, binding, @doc_path, 1
   end
-  
+
   def source_code *args
     src = args.pop
     lang = args.pop

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -8,11 +8,11 @@ require "rack/test"
 
 describe InstallFest do
   include Rack::Test::Methods
-  
+
   def app
     @app ||= InstallFest.new
   end
-  
+
   def true_app
     true_app = app
     while (next_app = true_app.instance_variable_get(:@app))
@@ -20,47 +20,47 @@ describe InstallFest do
     end
     true_app
   end
-  
+
   it "is a sinatra app" do
     assert { true_app.is_a? InstallFest }
     assert { true_app.class.ancestors.include? Sinatra::Application }
   end
-  
+
   it "redirects / to the default site" do
     get "/"
     assert { last_response.redirect? }
-    follow_redirect! while last_response.redirect?    
+    follow_redirect! while last_response.redirect?
     assert { last_request.path == "/installfest/installfest" }
   end
-  
+
   it "redirects /site to /site/site" do
     get "/installfest"
-    follow_redirect! while last_response.redirect?    
+    follow_redirect! while last_response.redirect?
     assert { last_request.path == "/installfest/installfest" }
   end
-  
+
   it "has a default site" do
     assert { true_app.default_site == "installfest" }
   end
-  
+
   it "accepts default_site via setter" do
     true_app.default_site = "curriculum"
     assert { true_app.default_site == "curriculum" }
   end
-  
+
   it "accepts default_site via Sinatra set" do
     pending "figure out Sinatra set"
     InstallFest.set :default_site, "curriculum"
     @app = InstallFest.new
     assert { true_app.default_site == "curriculum" }
   end
-  
+
   it "looks for a site named the same as the host" do
     get "/", {}, {"HTTP_HOST" => "curriculum.example.com"}
     assert { last_response.redirect? }
-    follow_redirect! while last_response.redirect?    
+    follow_redirect! while last_response.redirect?
     assert { last_request.path == "/curriculum/curriculum" }
   end
-  
+
 end
 

--- a/spec/step_page_spec.rb
+++ b/spec/step_page_spec.rb
@@ -25,7 +25,7 @@ describe StepPage do
     </div>
   </div>
 </div>
-    
+
     HTML
     assert { main_html == expected }
   end

--- a/spec/step_spec.rb
+++ b/spec/step_spec.rb
@@ -4,7 +4,7 @@ require "#{here}/spec_helper"
 require "step_page"
 
 describe Step do
-  
+
   def to_html nokogiri_node
     nokogiri_node.serialize(:save_with => 0).chomp
   end
@@ -18,7 +18,7 @@ describe Step do
       Nokogiri.parse("<html>#{@html}</html>")
     end
   end
-  
+
   it "renders a step file" do
     steps = html_doc.css(".step")
     html = to_html(steps.first)
@@ -29,14 +29,13 @@ describe Step do
     HTML
     assert { html == expected }
   end
-  
+
   it "puts titles in based on step names" do
     steps = html_doc.css(".step")
     assert { steps.first["title"] == "hello" }
     assert { steps[1]["title"] == "goodbye" }
   end
-  
-  
+
   it "puts anchors in based on step numbers" do
     steps = html_doc.css(".step")
     steps.each_with_index do |step, i|
@@ -54,12 +53,12 @@ describe Step do
     step "lunch" do
       step "salad"
       step "sandwich"
-    end    
+    end
     RUBY
 
     titles = html_doc.css('.step').map{|div| div["title"]}
     assert { titles = ["breakfast", "cereal", "eggs", "lunch", "salad", "sandwich"] }
-    
+
     anchors = html_doc.css("a")
     names = anchors.map{|a| a["name"]}
     assert { names == ["step1", "step1-1", "step1-2", "step2", "step2-1", "step2-2"] }
@@ -74,14 +73,14 @@ end
 step "lunch" do
   step "salad"
   step "sandwich"
-end    
+end
 RUBY
       a = html_doc.css(".step[title=breakfast] a.link").first
       hash = URI.escape '#'
       assert { a["href"] == "choose_breakfast?back=hello#{hash}step1" }
     end
   end
-  
+
   describe 'source_code' do
     it "emits a block of code as a pre with class 'code'" do
       html_doc(<<-RUBY)


### PR DESCRIPTION
It's not a cataclysmic, world-ending problem, but it does mess up paragraph navigation in Vim.

This patch removed line-trailing whitespace using the POSIX Regular expression `/\s+$/` (`/\vs+$/` in Vim).
