### PR TITLE
Rename the `note` command of the Step DSL to `markdown`.

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -220,9 +220,11 @@ div.back:before {
 
   ## notes
 
-  def note text
+  def markdown text
     p raw(md2html text)
   end
+
+  alias_method :note, :markdown
   
   def important text = nil
     div :class=>"important" do


### PR DESCRIPTION
This commit renames the method `Step#note` to `Step#markdown` as
discussed with @alexch. For backwards compatibility, a method alias
preserves the current behavior of `Step#note`, but will allow us to
change or add to the styling of notes in the future without affecting
cases where we really want plain, unstyled markdown. Rather than audit
each use of the note command in every file. I recommend that
contributors simply adjust usage as they add or change things.
