### PR TITLE
Implemented a proper-ish table of contents.

### DIFF
--- a/lib/contents.rb
+++ b/lib/contents.rb
@@ -1,12 +1,17 @@
 
 class Contents < Erector::Widget
-  needs :site_name
+  attr_accessor :site_dir
+  needs :site_name, :site_dir => nil
 
-  def site_dir
-    @site_dir ||= begin
+  def initialize options
+    super options
+
+    if options.include? :site_dir
+      self.site_dir = options[:site_dir]
+    else
       here = File.expand_path File.dirname(__FILE__)
       top = File.expand_path "#{here}/.."
-      "#{top}/sites/#{@site_name}"
+      self.site_dir = "#{top}/sites/#{@site_name}"
     end
   end
 
@@ -14,24 +19,150 @@ class Contents < Erector::Widget
     Dir.glob("#{site_dir}/*.{#{ext}}").sort
   end
 
-  def docs ext = "mw,md,step"
-    site_files(ext).map{|file| file.split('.').first}.uniq
+  def subpages_for filename
+    links = []
+    content = open("#{site_dir}/#{filename}").read()
+
+    # (markdown) links of the form: [link text](link_page)
+    content.scan /\[.*?\]\((.*?)\)/ do |link, _|
+      next if (link =~ /^http/)
+      next if (link =~ /(jpg|png)$/)
+      links.push(link) if !links.include? link
+    end
+
+    # (stepfiles) links of the form: link "next page"
+    content.scan /link\s*["'](.*?)["']/ do |link, _|
+      links.push(link) if !links.include? link
+    end
+
+    links
+  end
+
+  def next_step_for filename
+    content = open("#{site_dir}/#{filename}").read()
+
+    # (stepfiles) links of the form: stepfile "next page"
+    content.scan /next_step\s*["'](.*?)["']/ do |link, _|
+      return link
+    end
+
+    return nil
+  end
+
+  def collect_subpages page
+    if subpages[page] and !subpages[page].empty?
+      return [page] + subpages[page].map { |subpage| collect_subpages subpage }
+    end
+
+    return page
+  end
+
+  def find_next_page page
+    return nextpages[page] if nextpages[page]
+
+    if subpages[page]
+      return subpages[page].map { |subpage| find_next_page subpage }.compact.first
+    end
+
+    return nil
+  end
+
+  # Generate an array of pages on this site arranged hierarchically.
+  #
+  # The array is of the format:
+  # [
+  #   "root_page",
+  #   ["second_page",
+  #     "subpage_of_second_page",
+  #     "another_subpage_on_the_same_level"],
+  #   ["third_page",
+  #     ["subpage_of_third_page",
+  #       "subpage_of_subpage_of_third_page"]],
+  #   "fourth page"
+  # ]
+  # ... and so on
+  # This code assumes that a site is a linearly ordered series of pages
+  #   linked by "next_step" declarations.
+  # Each page can contain many subpages, and the "next_step" for the outer page
+  #   may be hidden deeply within the tree, but it must be there and it must be
+  #   unique (one side of the subtree branch shouldn't go to next_step "this"
+  #   while another goes to next_step "that").
+  def hierarchy
+    result = []
+    next_page = File.basename(site_dir)
+    while next_page do
+      this_page = next_page
+
+      result.push(collect_subpages this_page)
+
+      next_page = find_next_page this_page
+    end
+    result
+  end
+
+  def all_pages
+    site_files("mw,md,step").map { |file| File.basename(file).sub(/(\..*)$/, '') }.sort
+  end
+
+  def orphans
+    all_pages - hierarchy.flatten.uniq
+  end
+
+  def _page_links type="subpages"
+    site_files("mw,md,step").inject({}) do |result, filename|
+      page = File.basename(filename)
+      page_no_ext = page.sub(/(\..*)$/, '')
+      result[page_no_ext] = send("#{type}_for", page)
+      result
+    end
+  end
+
+  def subpages
+    @subpages ||=  _page_links("subpages")
+  end
+
+  def nextpages
+    @nextpages ||= _page_links("next_step")
+  end
+
+  def create_link page
+    link_text = page.split('_').map{|s|s.capitalize}.join(' ')
+    path = "/#{@site_name}/" + page
+    li { a(link_text, :href => path) }
+  end
+
+  def create_list toc_items
+    ul do
+      toc_items.each do |toc_item|
+        if toc_item.instance_of? Array
+          create_link toc_item.first
+          create_list toc_item[1..toc_item.length]
+        else
+          create_link toc_item
+        end
+      end
+    end
   end
 
   def content
     div class: "toc" do
       h1 "Contents"
-      docs.each do |path|
-        title = path.split('/').last.split('_').map{|s|s.capitalize}.join(' ')
-        path = path.gsub(/^#{site_dir}\//, "/#{@site_name}/")
-        li { a(title, :href => path) }
+      create_list hierarchy
+
+      unless orphans.empty?
+        h1 "Other Pages"
+        ul do
+          orphans.each { |orphan| create_link orphan }
+        end
       end
 
       h1 "Images"
-      site_files("jpg,png").each do |path|
-        title = path.split('/').last
-        path = path.gsub(/^#{site_dir}\//, '')
-        li { a(title, :href => path) }
+      ul do
+        site_files("jpg,png").each do |path|
+          title = File.basename(path)
+          path = path.gsub(/^#{site_dir}\//, '')
+          li { a(title, :href => path) }
+        end
       end
     end
   end

--- a/lib/doc_page.rb
+++ b/lib/doc_page.rb
@@ -85,7 +85,7 @@ class DocPage < Erector::Widgets::Page
     padding: 1em;
     margin: 0 0 1em 1em;
     float: right;
-    width: 18em;
+    width: 26em;
     overflow-x: hidden;
     display: none;
   }

--- a/sites/installfest/create_a_heroku_account.step
+++ b/sites/installfest/create_a_heroku_account.step
@@ -37,3 +37,4 @@ tip "If you have further Heroku issues" do
   message "try following [these directions](http://support.heroku.com/forums/43117/entries/32505) to install (or re-install) the `heroku` client."
 end
 
+next_step "create_and_deploy_a_rails_app"

--- a/sites/installfest/create_and_deploy_a_rails_app.step
+++ b/sites/installfest/create_and_deploy_a_rails_app.step
@@ -97,8 +97,6 @@ end
 
 step "Deploy your app to Heroku" do
 
-  link "create_a_heroku_account"
-
   step "Create a Heroku application from this local Rails application." do
 
   message "The very first time you use `heroku` you must enter your Heroku email address and password."

--- a/sites/installfest/macintosh.step
+++ b/sites/installfest/macintosh.step
@@ -48,7 +48,3 @@ step "Choose your instructions" do
   end
 end
 
-step "Get a sticker!" do
-  link "get_a_sticker"
-end
-

--- a/sites/installfest/osx_lion.step
+++ b/sites/installfest/osx_lion.step
@@ -74,12 +74,8 @@ step "Generate an ssh public key" do
   link "create_an_ssh_key"
 end
 
-step "Create a Heroku account" do
-  link "create_a_heroku_account"
-end
-
 step "Congratulations!" do
   message "You have everything you need to write a Ruby on Rails application."
 end
 
-next_step "create_and_deploy_a_rails_app"
+next_step "create_a_heroku_account"

--- a/sites/installfest/osx_panther.step
+++ b/sites/installfest/osx_panther.step
@@ -10,7 +10,7 @@ step "XCode tools " do
 
 These are part of OS X, but are not installed by default.
 
-* Insert your OS X DVD. ([xcode](xcode))
+* Insert your OS X DVD.
 
 * Look for Xcode.mkpg - it may be under "Optional Installs"
 
@@ -115,8 +115,4 @@ step "Create an SSH key" do
   link "create_an_ssh_key"
 end
 
-step "Create a Heroku account" do
-  link "create_a_heroku_account"
-end
-
-next_step "create_and_deploy_a_rails_app"
+next_step "create_a_heroku_account"

--- a/sites/installfest/ubuntu.step
+++ b/sites/installfest/ubuntu.step
@@ -75,4 +75,4 @@ MARKDOWN
   end
 end
 
-next_step "create_and_deploy_a_rails_app"
+next_step "create_a_heroku_account"

--- a/sites/installfest/windows.step
+++ b/sites/installfest/windows.step
@@ -116,8 +116,4 @@ step "Install a Text Editor" do
 
 end
 
-step "Create a Heroku Account " do
-  link "create_a_heroku_account"
-end
-
-next_step "create_and_deploy_a_rails_app"
+next_step "create_a_heroku_account"

--- a/spec/contents_spec.rb
+++ b/spec/contents_spec.rb
@@ -1,0 +1,61 @@
+here = File.expand_path File.dirname(__FILE__)
+require "#{here}/spec_helper"
+
+require "#{here}/../app"
+require "#{here}/../lib/contents"
+
+describe Contents do
+  before :all do
+    @meals_toc = Contents.new(site_name: 'meals', site_dir: "#{here}/sites/meals")
+  end
+
+  it "scans for subpage links" do
+    @meals_toc.subpages.should == {
+      "breakfast"=>[],
+      "clean_up"=>[],
+      "eat_a_meal"=>[],
+      "find_some_vegetables"=>[],
+      "meals"=>["breakfast"],
+      "omnivorous"=>[],
+      "orphaned_page"=>[],
+      "prepare_a_meal"=>["vegetarian", "omnivorous"],
+      "vegetarian"=>["find_some_vegetables"],
+    }
+  end
+
+  it "scans for next-page connections between pages" do
+    @meals_toc.nextpages.should == {
+      "breakfast"=>nil,
+      "clean_up"=>nil,
+      "eat_a_meal"=>"clean_up",
+      "find_some_vegetables"=>"eat_a_meal",
+      "meals"=>"prepare_a_meal",
+      "omnivorous"=>"eat_a_meal",
+      "orphaned_page"=>nil,
+      "prepare_a_meal"=>nil,
+      "vegetarian"=>nil,
+    }
+  end
+
+  it "knows the next logical page for a given page" do
+    @meals_toc.find_next_page('meals').should == 'prepare_a_meal'
+    @meals_toc.find_next_page('prepare_a_meal').should == 'eat_a_meal'
+  end
+
+  it "arranges pages hierarchically" do
+    @meals_toc.hierarchy.should == [
+      ["meals",
+       "breakfast"],
+      ["prepare_a_meal",
+       ["vegetarian",
+        "find_some_vegetables"],
+       "omnivorous"],
+      "eat_a_meal",
+      "clean_up"
+    ]
+  end
+
+  it "finds orphaned pages" do
+    @meals_toc.orphans.should == ["orphaned_page"]
+  end
+end

--- a/spec/sites/meals/clean_up.step
+++ b/spec/sites/meals/clean_up.step
@@ -1,0 +1,3 @@
+Throw all your things away!
+
+YOU'RE DONE!!

--- a/spec/sites/meals/eat_a_meal.step
+++ b/spec/sites/meals/eat_a_meal.step
@@ -1,0 +1,3 @@
+Put the food in your mouth!
+
+next_step "clean_up"

--- a/spec/sites/meals/find_some_vegetables.step
+++ b/spec/sites/meals/find_some_vegetables.step
@@ -1,0 +1,3 @@
+Green ones are good.
+
+next_step "eat_a_meal"

--- a/spec/sites/meals/meals.step
+++ b/spec/sites/meals/meals.step
@@ -1,0 +1,5 @@
+Here is your meals file.
+
+link "breakfast"
+
+next_step "prepare_a_meal"

--- a/spec/sites/meals/omnivorous.step
+++ b/spec/sites/meals/omnivorous.step
@@ -1,0 +1,3 @@
+You could use meat if you wanted to.
+
+next_step "eat_a_meal"

--- a/spec/sites/meals/orphaned_page.step
+++ b/spec/sites/meals/orphaned_page.step
@@ -1,0 +1,1 @@
+No page links to me! Why?

--- a/spec/sites/meals/prepare_a_meal.step
+++ b/spec/sites/meals/prepare_a_meal.step
@@ -1,0 +1,4 @@
+Are you
+link "vegetarian"
+or
+link "omnivorous"

--- a/spec/sites/meals/vegetarian.step
+++ b/spec/sites/meals/vegetarian.step
@@ -1,0 +1,3 @@
+Make sure not to use any meat!
+
+link "find_some_vegetables"


### PR DESCRIPTION
This patch changes the table of contents generation to generate a hierarchical list by scanning all files in the site for links between them.

One extreme negative is that it does this on every single pageload; this activity should probably be memoized in some way, but I don't really know how to go about doing that (probably break out the file-scanning stuff from the Contents widget into some other object that can keep state for the life of the server).

But I think it's better than it was?
