### PR TITLE
Removed the "edit ~/.bash_profile" step with RVM: these days, RVM edits ...

### DIFF
--- a/sites/installfest/install_rvm.step
+++ b/sites/installfest/install_rvm.step
@@ -16,9 +16,7 @@ end
 
 step "Configure your shell" do
 
-  message "Every time you open a new terminal window, rvm will be active inside it. But for **this** terminal window, you need to run this command:"
-
-  console "source ~/.bash_profile"
+  message "Every time you open a new terminal window, rvm will be active inside it. Close your terminal window and open a new one."
 
   verify do
     console "type rvm | head -1"


### PR DESCRIPTION
...~/.bashrc -- it's easier and future-proof to just tell people to restart the terminal.
