### PR TITLE
Made the Table of Contents a positioned element so images don't show over it.

### DIFF
--- a/lib/doc_page.rb
+++ b/lib/doc_page.rb
@@ -88,6 +88,8 @@ class DocPage < Erector::Widgets::Page
     width: 26em;
     overflow-x: hidden;
     display: none;
+    /* if the toc isn't "positioned", images will show on top of it */
+    position: relative;
   }
 
   .main {


### PR DESCRIPTION
Previously, on pages with images (like [site]/frontend) if your browser window was
  small enough that the image collided with an open TOC, the image would show over
  the TOC, making it very difficult to use.
