### PR TITLE
Add instructions to add flash code to application layout view file. 

### DIFF
--- a/sites/curriculum/redirect_to_the_topics_list_after_creating_a_new_topic.step
+++ b/sites/curriculum/redirect_to_the_topics_list_after_creating_a_new_topic.step
@@ -41,6 +41,18 @@ end
     RUBY
   end
 
+  step "Add the flash message to your application view" do
+      message "Open `app/views/layouts/application.html.erb`."
+
+      message "Find the `<body>` HTML tag and immediately after add the following code:"
+
+      source_code :ruby, <<-RUBY
+<% flash.each do |name, msg| %>
+    <div><%= msg %></div>
+<% end %>
+      RUBY
+  end
+
   step "Confirm your changes" do
     message "Look at <http://localhost:3000>."
   end


### PR DESCRIPTION
This is for the page: 

```
Redirect To The Topics List After Creating A New Topic
```

There are instructions for adding the flash notice message to the redirect_to, but the view is missing the flash object so when creating a new topic and being redirected, the student does not see the flash notice message. 
