### PR TITLE
Removed the 'onclick' from table of contents list items.

### DIFF
--- a/lib/contents.rb
+++ b/lib/contents.rb
@@ -128,7 +128,7 @@ class Contents < Erector::Widget
   def create_link page
     link_text = page.split('_').map{|s|s.capitalize}.join(' ')
     path = "/#{@site_name}/" + page
-    li(:onclick => "document.location='#{path}'") { a(link_text, :href => path) }
+    li { a(link_text, :href => path) }
   end
 
   def create_list toc_items

--- a/lib/doc_page.rb
+++ b/lib/doc_page.rb
@@ -120,6 +120,7 @@ class DocPage < Erector::Widgets::Page
 
   .toc ul li a {
     text-decoration: none;
+    display: block; /* fill the entire containing li */
   }
 
 


### PR DESCRIPTION
It was there to allow the entire 'li' to be clickable, but setting
  the 'a' itself to "display: block;" solves that while preserving
  normal click semantics (like middle click).
