### PR TITLE
Skip Homebrew/git if git is already installed

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -153,6 +153,7 @@ div.back:before {
   def step name = nil, options = {}
     num = next_step_number
     a(:name => "step#{current_anchor_num}")
+    a(:name => options[:anchor_name]) if options[:anchor_name]
     div :class => "step", :title => name do
       h1 do
         widget BigCheckbox

--- a/sites/installfest/osx_lion.step
+++ b/sites/installfest/osx_lion.step
@@ -13,7 +13,7 @@ end
 step "Install Homebrew" do
   console "which git"
   result "/usr/bin/git"
-  message "If you get the result above skip to: <a href='#step5'>Step 5</a>" 
+  message "If you get the result above skip to: <a href='#install_rvm'>Install RVM</a>" 
   link "install_homebrew"
 end
 
@@ -30,7 +30,7 @@ step "Install Git" do
   link "configure_git"
 end
 
-step "Install RVM, the Ruby Version Manager " do
+step "Install RVM, the Ruby Version Manager ", {:anchor_name => 'install_rvm'} do
   link "install_rvm"
 end
 

--- a/spec/step_spec.rb
+++ b/spec/step_spec.rb
@@ -45,6 +45,16 @@ describe Step do
       assert { to_html(step.previous) == "<a name=\"step#{i+1}\"></a>" }
     end
   end
+  
+  it "puts anchors in based on optional step name" do
+    html_doc(<<-RUBY)
+    step "Test", {:anchor_name => 'happy_step'}
+    RUBY
+    
+    anchors = html_doc.css("a")
+    names = anchors.map{|a| a["name"]}
+    assert { names == ["step1", "happy_step"] }
+  end
 
   it "nests anchor numbers" do
     html_doc(<<-RUBY)


### PR DESCRIPTION
git is being installed with the XCode command line tools with the most recent version of Lion (10.7.4), so the homebrew and git installs can be skipped if they already have git. So I added a check, a message, and a link for students to skip the homebrew and git install if it's already installed.
