### PR TITLE
Updated Steps and Explanation to be consistent with each other 

### DIFF
--- a/sites/curriculum/allow_people_to_vote.step
+++ b/sites/curriculum/allow_people_to_vote.step
@@ -14,7 +14,7 @@ steps {
       <td><%= topic.title %></td>
       <td><%= topic.description %></td>
       <td><%= pluralize(topic.votes.length, "vote") %></td>
-      <td><%= button_to '+1', votes_path(topic_id: topic.id), method: :post %></td>
+      <td><%= button_to '+1', votes_path(topic_id => topic.id), method => :post %></td>
       <td><%= link_to 'Show', topic %></td>
       <td><%= link_to 'Edit', edit_topic_path(topic) %></td>
       <td><%= link_to 'Destroy', topic, confirm: 'Are you sure?', method: :delete %></td>
@@ -45,13 +45,15 @@ end
 
 explanation {
 
-  message "First we added this line to `app/views/topics/index.html.erb`"
+  message "First we added these two lines to `app/views/topics/index.html.erb`"
   source_code :erb, <<-HTML
+  <td><%= pluralize(topic.votes.length, "vote") %></td>
   <td><%= button_to '+1', votes_path(:topic_id => topic.id), :method => :post %></td>
   HTML
 
   message <<-MARKDOWN
-  * `button_to '+1'` creates an html button with the value '+1'
+  * `pluralize(topic.votes.length, "vote")' displays the number of votes the topic has, plus the word 'vote' or 'votes' accordingly.
+  * `button_to '+1'` creates an html button with the value '+1'.
   * `votes_path(:topic_id => topic.id)` creates the right url for the action we want to invoke. In this case, we want to create a vote for the current topic.
     * `votes_path(:topic_id => 42)` would output `/votes?topic_id=42`
   * `:method => :post` ensures we do the create action of CRUD, not the read action.


### PR DESCRIPTION
1. updated code in Steps to be consistent with "=>" used in Explanation rather than ":"
2. added explanation of the use of the pluralize function to show # votes, which wasn't previously explained, into Explanation 
