### PR TITLE
Installfest attendees should not be given the option to destroy their Heroku apps from the command line.

### DIFF
--- a/sites/installfest/clean_up.step
+++ b/sites/installfest/clean_up.step
@@ -4,12 +4,7 @@ Ok, there is one more step. You won't be using the test application in the works
 MARKDOWN
 
 step "Delete the app from Heroku" do
-  option "from the browser" do
-    message "Go to <https://heroku.com/myapps> and then click on your app name. Scroll to the bottom of the page and click Destroy App."
-  end
-  option "from the command line" do
-    console "heroku apps:destroy"
-  end
+  message "Go to <https://heroku.com/myapps> and then click on your app name. Scroll to the bottom of the page and click Destroy App."
 end
 
 step "Delete test_app from your computer" do


### PR DESCRIPTION
Currently, the "clean up" page gives you two options for destroying a Heroku app: through the web UI, or through the command line. I watched a student of the "gotta type everything in black!" flavor try to do both in sequence.

I don't think there's much reason to give both options: the web UI is more straightforward compared to the command line, which typically goes like this:

```
Traviss-MacBook-Air:awesome_app tjgrathwell$ heroku apps:destroy
 !    Usage: heroku apps:destroy --app APP
Traviss-MacBook-Air:awesome_app tjgrathwell$ heroku apps:destroy --app APP
 !    App not found.
Traviss-MacBook-Air:awesome_app tjgrathwell$ heroku info
=== empty-stream-2789
Domain Name:   empty-stream-2789.herokuapp.com
Git URL:       git@heroku.com:empty-stream-2789.git
Owner:         tjgrathwell@gmail.com
Stack:         cedar
Web URL:       http://empty-stream-2789.herokuapp.com/
Traviss-MacBook-Air:awesome_app tjgrathwell$ heroku apps:destroy --app empty-stream-2789

 !    WARNING: Potentially Destructive Action
 !    This command will destroy empty-stream-2789 (including all add-ons).
 !    To proceed, type "empty-stream-2789" or re-run this command with --confirm empty-stream-2789

> empty-stream-2789
Destroying empty-stream-2789 (including all add-ons)... done
Traviss-MacBook-Air:awesome_app tjgrathwell$
```
