### PR TITLE
Removed the section about ri, added --no-ri and --no-rdoc flags.

### DIFF
--- a/sites/curriculum/tools.step
+++ b/sites/curriculum/tools.step
@@ -1,38 +1,6 @@
 message <<-MARKDOWN
 ## Other Tools to help you learn Ruby
 
-### ri
-
-ri is a tool to look up ruby documentation:
-
-    $ ri String.split
-    = String.split
-
-    (from ruby core)
-    ------------------------------------------------------------------------------
-      str.split(pattern=$;, [limit])   => anArray
-
-    ------------------------------------------------------------------------------
-
-    Divides str into substrings based on a delimiter, returning an array of
-    these substrings.
-    ...
-
-MARKDOWN
-
-important "If running ri doesn't work and you've installed ruby using rvm, try
-running this command first:
-
-    $ rvm docs generate
-"
-
-message <<-MARKDOWN
-You can do a lot with it:
-
-* `ri Class` -- looks up the class documentation and shows all the methods available.
-* `ri Class.method` -- looks up a specific method on a class or module.
-* `ri method` -- searches all classes for matching methods
-
 ### irb
 
 We've already introduced irb above, but it can't be stressed enough
@@ -45,8 +13,7 @@ You can do stuff like:
     >> "blah".methods
     => [:<=>, :==, :===, :eql?, :hash, :casecmp, :+, :*, :%, :[], :[]=, :insert, :length, :size...]
 
-All of these methods are available for any string. You can then use
-`ri` to look up the method documentation. It is a great way to find goodies!
+All of these methods are available for any string. To find out more about what these methods do and how to use them, try searching for "String" on [ruby-doc.org](http://www.ruby-doc.org). It is a great way to find goodies!
 
 ### online resources
 

--- a/sites/installfest/create_a_heroku_account.step
+++ b/sites/installfest/create_a_heroku_account.step
@@ -17,11 +17,11 @@ end
 step "Install the heroku gem" do
 
   option "if you are using rvm" do
-    console "rvm @global gem install heroku"
+    console "rvm @global gem install heroku --no-rdoc --no-ri"
   end
 
   option "otherwise" do
-    console "gem install heroku"
+    console "gem install heroku --no-rdoc --no-ri"
   end
 
   verify do

--- a/sites/installfest/osx_lion.step
+++ b/sites/installfest/osx_lion.step
@@ -35,7 +35,7 @@ step "Install RVM, the Ruby Version Manager ", {:anchor_name => 'install_rvm'} d
 end
 
 step "Install Rails" do  
-  console "gem install rails"
+  console "gem install rails --no-rdoc --no-ri"
   verify do
     console "rails -v"
     result "Rails 3.2.6"
@@ -51,7 +51,7 @@ step "Install KomodoEdit" do
 end
 
 step "Install the heroku tool" do
-  console "gem install heroku"
+  console "gem install heroku --no-rdoc --no-ri"
 end
 
 verify "successful installation" do

--- a/sites/installfest/osx_panther.step
+++ b/sites/installfest/osx_panther.step
@@ -48,10 +48,10 @@ step "Ruby, RubyGems, and Rails " do
     important "Whenever you install a gem using the built-in Ruby you should precede 'gem install' with 'sudo'"
   end
   console <<-BASH
-sudo gem install rubygems-update
+sudo gem install rubygems-update --no-rdoc --no-ri
 sudo update_rubygems
 sudo gem update --system
-sudo gem install rails
+sudo gem install rails --no-rdoc --no-ri
   BASH
 
   message <<-MARKDOWN
@@ -62,9 +62,9 @@ If you are having this error:
 Try the steps in this order:
 
     sudo gem update --system
-    sudo gem install rubygems-update
+    sudo gem install rubygems-update --no-rdoc --no-ri
     sudo update_rubygems
-    sudo gem install rails
+    sudo gem install rails --no-rdoc --no-ri
 
 For Tiger ONLY:
 

--- a/sites/installfest/ubuntu.step
+++ b/sites/installfest/ubuntu.step
@@ -40,7 +40,7 @@ end
 step "Rails " do
   message "Using a terminal again, execute the following command to install rails."
 
-  console "gem install rails"
+  console "gem install rails --no-rdoc --no-ri"
 end
 
 step "Firefox" do


### PR DESCRIPTION
1. I don't know anyone who actually uses ri & rdoc in real life :)
2. generating ri & rdoc usually takes more time than installing the gems themselves
3. ri is sloooooowwwww
4. For beginners, the ri "UI" and the query interface is confusing
5. Google / ruby-doc.org is much faster/easier to read
6. Running `rvm docs generate` during class is a waste of time

I don't think anyone is going to miss them :P
