### PR TITLE
Rename installfest -> docs to clear things up.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then open <http://localhost:9292> in a web browser.
 
 This is a Sinatra app, deployed at <http://docs.railsbridge.org>. The Railsbridge documentation project is home to a few subprojects, including the Railsbridge installfest instructions, which leads students through the various complicated setup instructions for getting Ruby, Rails, Git, etc. installed on their computer (whatever combination of computer, OS, and version they happened to bring the the workshop!), as well as the Railsbridge workshop "Suggestotron" curriculum.
 
-Each subproject (a "site") comprises files stored under the "site" directory; for instance, the installfest instructions are located at ROOT/sites/installfest, while the curriculum can be found under ROOT/sites/curriculum.
+Each subproject (a "site") comprises files stored under the "sites" directory; for instance, the installfest instructions are located at ROOT/sites/installfest, while the curriculum can be found under ROOT/sites/curriculum.
 
 These files can be in any of these formats:
 
@@ -38,7 +38,7 @@ StepFile is a new, Ruby-based DSL for describing complex, nested instructions in
 
 #Organizer Instructions
 
-Slide contents that change with each workshop are contained in three files unders the workshop project. The 'hello and welcome, this is when the breaks are' presentation slides are in current.deck.md. The 'this is what we will learn today' slides are in welcome.deck.md. And the 'this is what we have learned' slides are in closing.deck.md.
+Slide contents that change with each workshop are contained in three files under the workshop project. The 'hello and welcome, this is when the breaks are' presentation slides are in current.deck.md. The 'this is what we will learn today' slides are in welcome.deck.md. And the 'this is what we have learned' slides are in closing.deck.md.
 
 To change those contents, clone this repo, make changes, and then to include your changes in the publicly available repo, send a pull request.
 


### PR DESCRIPTION
Cleared up some potential confusing references to the "installfest step list" since this repo is now used for multiple things now.

Before accepting this PR, these need to happen:
1. http://docs.railsbridge.com need to exist :) [Or we can just use http://workshops.railsbridge.org, although we will end up with http://workshop.railsbridge.org/workshop, and to top that, we currently have http://workshops.railsbridge.org. Whereas http://docs.railsbridge.org mirrors the repo name nicely :)]
2. Setup the redirects from all the old urls
3. Maybe add an index of all the different sites/projects from the root URL, instead of redirecting to /workshop or /installfest (This can come as a separate PR later)
