### PR TITLE
adding notice for windows users about irb bug in git bash

### DIFF
--- a/sites/workshop/ruby_for_beginners.deck.md
+++ b/sites/workshop/ruby_for_beginners.deck.md
@@ -67,6 +67,10 @@
 
     $ irb
 
+    Windows Users! Some people have experienced trouble with backspace, delete, and arrow keys working properly in irb - what a pain! If you run into this problem, use this command instead to launch irb.
+
+    $ irb --noreadline
+
 !SLIDE
 
 ## Variables


### PR DESCRIPTION
At Madison Ruby Conf, a pair of Windows users ran into this issue. Adding --no-readline fixed the problem, as outlined here:

http://stackoverflow.com/questions/5660209/backspace-and-arrow-keys-arent-working-in-irbgit-bash-console-on-windows-mach
