### PR TITLE
remove console command overviews where redundant

### DIFF
--- a/sites/curriculum/creating_a_migration.step
+++ b/sites/curriculum/creating_a_migration.step
@@ -18,13 +18,6 @@ goals {
 
 steps {
 
-  console <<-SHELL
-rails generate scaffold topic title:string description:text
-rake db:migrate
-rails server
-  SHELL
-
-  message "If you want, take some time to poke around the files listed in the generate step."
 
   step {
     console "rails generate scaffold topic title:string description:text"
@@ -34,6 +27,7 @@ rails server
 * `title:string` says that topics have a title, which is a string.
 * `description:text` says that topics have a description which is a "text". (We're befuddled by the difference too).
     MARKDOWN
+    message "If you want, take some time to poke around the files listed in this step."
   }
 
   step {

--- a/sites/curriculum/getting_started.step
+++ b/sites/curriculum/getting_started.step
@@ -10,16 +10,6 @@ steps do
 
   tip "If you have _any_ problems, contact a TA immediately."
 
-  console <<-SHELL
-mkdir railsbridge
-cd railsbridge
-rails new suggestotron
-cd suggestotron
-ls
-  SHELL
-
-  message "Here's a step-by-step breakdown, with explanations:"
-
   step do
     console "mkdir railsbridge"
     message "'mkdir' stands for make directory (folder)."


### PR DESCRIPTION
There were two last errant console command overviews that ended up instructing students to run that page's commands twice. 
