### PR TITLE
clean up tools page

### DIFF
--- a/sites/curriculum/credits_and_next_steps.step
+++ b/sites/curriculum/credits_and_next_steps.step
@@ -1,20 +1,21 @@
 h1 "Authors"
 
-ul {
+ul do
   li "Sarah Allen"
   li "Sarah Mei"
   li "Alex Chaffee"
   li "Ryan Davis"
   li "Steven! Ragnarok"
-  li "...and many others"
-}
+  li "...and many, many others"
+end
 
 h1 "What next?"
 
-ul {
-  li "Learn More Ruby"
-  li "Learn More Rails"
-  li "Take a class"
-  li "Be a TA at an upcoming workshop"
-  li "...?"
-}
+ul do
+  li "Probably time for the closing presentation." 
+  li "After that, start a project, tutorial, and come back again!"
+  li do 
+    span "All our favorite resources can be found on the RailsBridge site: " 
+    a "http://workshops.railsbridge.org/whats-next/", href: "http://workshops.railsbridge.org/whats-next/"
+  end
+end

--- a/sites/curriculum/tools.step
+++ b/sites/curriculum/tools.step
@@ -2,17 +2,16 @@ message <<-MARKDOWN
 ## Other Tools to help you learn Ruby
 
 ### ri
-
-ri is a tool to look up ruby documentation:
+ri is a tool to look up ruby documentation. It lives on your computer, so if you're in a plane or underground bunker and can't get to google, all the information right within the terminal! If you do prefer the internet, you can get the same information at [ruby-doc.org](http://ruby-doc.org).
 
     $ ri String.split
     = String.split
 
     (from ruby core)
-    ------------------------------------------------------------------------------
+    -------------------------------------------------------------------------
       str.split(pattern=$;, [limit])   => anArray
 
-    ------------------------------------------------------------------------------
+    -------------------------------------------------------------------------
 
     Divides str into substrings based on a delimiter, returning an array of
     these substrings.
@@ -20,8 +19,7 @@ ri is a tool to look up ruby documentation:
 
 MARKDOWN
 
-important "If running ri doesn't work and you've installed ruby using rvm, try
-running this command first:
+important "If running ri doesn't work and you've installed ruby using rvm, try running this command first:
 
     $ rvm docs generate
 "
@@ -35,28 +33,15 @@ You can do a lot with it:
 
 ### irb
 
-We've already introduced irb above, but it can't be stressed enough
-that having an interactive live session with ruby is invaluable. You
-can learn a lot from it.
+We've already introduced irb above, but it can't be stressed enough that having an interactive live session with ruby is invaluable. You can learn a lot from it.
 
 You can do stuff like:
 
     $ irb
     >> "blah".methods
-    => [:<=>, :==, :===, :eql?, :hash, :casecmp, :+, :*, :%, :[], :[]=, :insert, :length, :size...]
+    => [:<=>, :==, :===, :eql?, :hash, :casecmp...]
 
-All of these methods are available for any string. You can then use
-`ri` to look up the method documentation. It is a great way to find goodies!
-
-### online resources
-
-* [Ruby Quickref](http://www.zenspider.com/Languages/Ruby/QuickRef.html)
-* Google - searching "ruby" and whatever you're looking for usually leads to good stuff.
-* [Ruby Koans](http://rubykoans.com/) - a great set of lessons in an interactive form.
-* [Test First Training](http://testfirst.org) - learn Ruby, one test at a time.
-* [Learn to Program by Chris Pine](http://pine.fm/LearnToProgram) - also available as [a book](http://pragprog.com/book/ltp2/learn-to-program).
-* [The Pickaxe](http://pragprog.com/book/ruby3/programming-ruby-1-9) - The definitive ruby reference (and has a great tutorial too).
-* [Why's (poignant) Guide to Ruby](http://www.scribd.com/doc/8545174/whys-Poignant-Guide-to-Ruby) - the (crazy) guide to ruby... Try it, you might like it.
+All of these methods are available for any string. You can then use `ri` to look up the method documentation. It is a great way to find goodies!
 
 MARKDOWN
 


### PR DESCRIPTION
Moved resources links to page on workshops.railsbridge.org and linked to that from the final slide. Cleaned up Tools page.
