### PR TITLE
Fixed broken Heroku version check step.

### DIFF
--- a/sites/installfest/create_a_heroku_account.step
+++ b/sites/installfest/create_a_heroku_account.step
@@ -25,7 +25,7 @@ step "Install the heroku gem" do
   end
 
   verify do
-    console "heroku -v"
+    console "heroku version"
     result "2.26.7 or higher"
   end
 end


### PR DESCRIPTION
While going through the installfest instructions at Railsbridge LA, I discovered that `heroku -v` didn't work.  The updated command is `heroku version`.  I fixed the docs to reflect that (and ran the tests).
