### PR TITLE
Remove instructions to fork a demo repo and rename

### DIFF
--- a/sites/frontend/get_a_sticker.step
+++ b/sites/frontend/get_a_sticker.step
@@ -39,31 +39,21 @@ verify "you can clone from GitHub do" do
       message "When the page finishes loading you will be on your own copy of the project"
     end
 
-    step "Change the Name" do
-      message 'Find and click on the "Settings" button.'
-      img :src => "get_a_sticker_admin_button.png"
-      message "On the Settings page, you will see a settings box."
-      img :src => "get_a_sticker_admin_settings.png"
-      message "Change the repository name from `front-end-lesson` to `your_github_username.github.com`"
-      message "For example, if your github username is `superhacker` change the repository name to `superhacker.github.com`"
-      message "GitHub will warn you about \"bad things\". You can safely ignore this since none of them apply to you."
+    step "Clone it Locally" do
+      message "On the page for your GitHub project, find the \"http\" button or \"copy to clipboard\""
+      img :src => "get_a_sticker_https.png"
+      message "Copy the linked url and clone the repository using git"
+      tip "On Mac OS X, you can paste into the Terminal like normal using `⌘+v`, Windows users can paste by right-clicking on the terminal and selecting Paste from the menu."
+      console "git clone <THAT LINK YOU COPIED>"
+
+      result <<-OUTPUT
+        Cloning into 'front-end-lesson'...
+        remote: Counting objects: 27, done.
+        remote: Compressing objects: 100% (20/20), done.
+        remote: Total 27 (delta 6), reused 26 (delta 5)
+        Unpacking objects: 100% (27/27), done.
+      OUTPUT
     end
-  end
-
-  step "Clone it Locally" do
-    message "On the page for your GitHub project, find the \"http\" button or \"copy to clipboard\""
-    img :src => "get_a_sticker_https.png"
-    message "Copy the linked url and clone the repository using git"
-    tip "On Mac OS X, you can paste into the Terminal like normal using `⌘+v`, Windows users can paste by right-clicking on the terminal and selecting Paste from the menu."
-    console "git clone <THAT LINK YOU COPIED>"
-
-    result <<-OUTPUT
-Cloning into 'mrsteven.github.com'...
-remote: Counting objects: 27, done.
-remote: Compressing objects: 100% (20/20), done.
-remote: Total 27 (delta 6), reused 26 (delta 5)
-Unpacking objects: 100% (27/27), done.
-    OUTPUT
   end
 end
 


### PR DESCRIPTION
Recently added commit https://github.com/railsbridge/docs/commit/a6dc832c4c8e26a09647d15ee5e635b12819e2d9 will fail. This is because, in get_a_sticker.step, there are instructions to clone a repo and rename it. The name that a6dc832c4 instructs students to use will collide with the existing renamed fork. 

Since the fork/rename step is a somewhat non-standard workflow, and not particularly relevant to working on the front-end, I've removed it.

(also fixed some formatting problems with the following step in that file)
