### PR TITLE
Configure ubuntu terminal before installing rvm instead of after

### DIFF
--- a/sites/installfest/ubuntu.step
+++ b/sites/installfest/ubuntu.step
@@ -50,12 +50,12 @@ step "Configure Git" do
 end
 
 step "Install RVM" do
-  link "install_rvm_and_ruby"
-  message "Restart your terminal before continuing."
   important do
-    message "If you're using Ubuntu 12.04 or the latest version of Mint, ensure that the Run command as login shell option is checked under the Title and Command tab in Profile Preferences. After changing this setting, you may need to exit your console session and start a new one before the changes take affect." 
+    message "If you're using Ubuntu 12.04 or the latest version of Mint, ensure that the Run command as login shell option is checked under the Title and Command tab in Profile Preferences. After changing this setting, you may need to exit your console session and start a new one before the changes take affect."
     img src: 'railsbridge_ubuntu12-checkbox.png', alt: "Ubuntu 12.04 terminal settings"
   end
+  link "install_rvm_and_ruby"
+  message "Restart your terminal before continuing."
 end
 
 step "Install Rails" do


### PR DESCRIPTION
This just re-orders the step, putting the warning first.

A small change, but we had a couple students miss the note when they came back from the  
'install rvm and ruby' page.
