### PR TITLE
fix syntax for float examples in beginner slide deck

### DIFF
--- a/sites/workshop/ruby_for_beginners.deck.md
+++ b/sites/workshop/ruby_for_beginners.deck.md
@@ -278,10 +278,10 @@ What is happening on the last two lines?  How would you solve it?
 	* 898989898
 	* 2
 * Examples of floats:	
-	* .0.0
+	* 0.0
 	* -105.56
-	* .33
-	* .00004
+	* 0.33
+	* 0.00004
 * You can perform operations on both types of numbers with these characters: +, -, /, *
 	
 ### exercises	


### PR DESCRIPTION
Previous examples were not valid Ruby syntax. `.0.0` and `.33` would result in a syntax error if typed as is.
