### PR TITLE
fixing markdown issue on curriculum page

### DIFF
--- a/sites/curriculum/curriculum.step
+++ b/sites/curriculum/curriculum.step
@@ -57,7 +57,8 @@ $ irb
 >> require "active_support"
 => true
 >> exit
-$</pre></div>
+$</pre>
+</div>
 
 If you can do that, you are probably good to go.
 


### PR DESCRIPTION
needed a newline between /pre and /div
