### PR TITLE
Update src link to toggle between source and text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .idea
 Thumbs.db
 .rvmrc
+.ruby-version
 .sass-cache

--- a/lib/doc_page.rb
+++ b/lib/doc_page.rb
@@ -91,11 +91,15 @@ class DocPage < Erector::Widgets::Page
     "https://github.com/railsbridge/docs/blob/master/sites/#{@site_name}/#{file_name}"
   end
 
+  def src_url
+    "#{file_name.split('.').first}/src"
+  end
+
   def top_links
     [
       TopLink.new(name: "toc", href: "#", extraclass: 'show-when-small', toggle_selector: '#table_of_contents'),
       TopLink.new(name: "sites", href: "#", toggle_selector: '#site_index'),
-      TopLink.new(name: "src", href: "#{file_name.split('.').first}/src"),
+      TopLink.new(name: "src", href: src_url),
       TopLink.new(name: "git", href: git_url),
     ]
   end

--- a/lib/raw_page.rb
+++ b/lib/raw_page.rb
@@ -2,6 +2,9 @@ require 'erector'
 require 'doc_page'
 
 class RawPage < DocPage
+  def src_url
+    "../#{file_name.split('.').first}"
+  end
 
   def show_src?
     false


### PR DESCRIPTION
Currently the Src link in the header will goto the source on the first click, then to a 404 on second click. Changing behavior to toggle between source and the text.
- added src_url method to DocPage and replaced src link href with call to src_url
- override src_url in RawPage to link back to text of page
- add .ruby-version to .gitignore as rvm now uses .ruby-version files
