### PR TITLE
change load file example slide to use same prompt as other irb examples

### DIFF
--- a/sites/workshop/ruby_for_beginners.deck.md
+++ b/sites/workshop/ruby_for_beginners.deck.md
@@ -539,9 +539,9 @@ In your text editor, create a file named `my_program.rb` inside your working dir
 
 ```bash
   $ irb
-  ruby > load 'my_program.rb'
-  ruby > second_time=Sample.new
-  ruby > second_time.hello
+  > load 'my_program.rb'
+  > second_time=Sample.new
+  > second_time.hello
 ```
 
 When might it be useful to do this?


### PR DESCRIPTION
Some students in my group got confused when the irb prompts in the slides changed and typed in `ruby >` which didn't work.
