### PR TITLE
correct capitalization of About This Mac

### DIFF
--- a/sites/installfest/macintosh.step
+++ b/sites/installfest/macintosh.step
@@ -2,7 +2,7 @@ step "Learn your Mac OS X Version" do
   message <<-MARKDOWN
 
 * Click on the Apple icon in the top left of your screen.
-* Select "About this Mac"
+* Select "About This Mac"
 * In the window that comes up, under the title "Mac OS X" there will be a version number.
   * If it starts with 10.8, you have **Mountain Lion**.
   * If it starts with 10.7, you have **Lion**.
@@ -11,7 +11,7 @@ step "Learn your Mac OS X Version" do
   * If it starts with 10.4, you have **Tiger**.
   * If it starts with 10.3, you have **Panther**.
 
-* Write down the one you have and close the "About this Mac" window.
+* Write down the one you have and close the "About This Mac" window.
 
 Below is an example.
 


### PR DESCRIPTION
The word "This" was capitalized sometime in the 10.3 days. Our docs should match what the student sees.
