### PR TITLE
Alert for Heroku Deployment

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -80,7 +80,7 @@ class Step < Erector::Widget
     div :class => "deploying" do
       h1 "Deploying"
       blockquote do
-        message "Before the next step, you could try deploying your app to Heroku!"
+        message "Before the next step, you could try deploying your app to Heroku! Note, that until you reach the stage 'Setting The Default Page', Heroku may tell you 'The page you were looking for doesn't exist'."
         link 'deploying_to_heroku'
       end
     end


### PR DESCRIPTION
Hello!

I was a student at the Orlando RailsBridge earlier this year, and a TA in Savannah this past weekend. With some students now using Rails 4, we ran into some confusion when deploying to Heroku. In Rails 4, the welcome page that’s usually displayed when visiting a new application’s home page doesn't render. Instead, visitors are shown a 404 with 'The page you were looking for doesn't exist'. 

![screen shot 2013-07-16 at 9 37 16 pm](https://f.cloud.github.com/assets/2165184/809319/0430b0e8-ee82-11e2-8268-778e1d260517.png)

My proposed change includes a brief note alerting that this warning may occur until 'Setting The Default Page' later in the curriculum. 
