### PR TITLE
Changes for Rails 4 Heroku Deployment

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -80,7 +80,7 @@ class Step < Erector::Widget
     div :class => "deploying" do
       h1 "Deploying"
       blockquote do
-        message "Before the next step, you could try deploying your app to Heroku! Note, that until you reach the stage 'Setting The Default Page', Heroku may tell you 'The page you were looking for doesn't exist'."
+        message "Before the next step, you could try deploying your app to Heroku!"
         link 'deploying_to_heroku'
       end
     end

--- a/sites/curriculum/CRUD_with_scaffolding.step
+++ b/sites/curriculum/CRUD_with_scaffolding.step
@@ -104,6 +104,4 @@ explanation {
     MARKDOWN
 }
 
-consider_deploying
-
-next_step "voting_on_topics"
+next_step "setting_the_default_page"

--- a/sites/curriculum/allow_people_to_vote.step
+++ b/sites/curriculum/allow_people_to_vote.step
@@ -71,4 +71,6 @@ explanation {
 
 consider_deploying
 
-next_step "setting_the_default_page"
+next_step
+"redirect_to_the_topics_list_after_creating_a_new_topic"
+

--- a/sites/curriculum/running_your_application_locally.step
+++ b/sites/curriculum/running_your_application_locally.step
@@ -30,6 +30,4 @@ explanation do
   message "Control+C is a way of closing or cancelling terminal programs. Since rails server runs forever, you need to interrupt it with Control+C."
 end
 
-consider_deploying
-
 next_step "creating_a_migration"

--- a/sites/curriculum/setting_the_default_page.step
+++ b/sites/curriculum/setting_the_default_page.step
@@ -92,4 +92,6 @@ explanation {
   MARKDOWN
 }
 
-next_step "redirect_to_the_topics_list_after_creating_a_new_topic"
+consider_deploying
+
+next_step "voting_on_topics"


### PR DESCRIPTION
Travis,

As discussed, below are the list of changes to the new PR.
1. Removed 'consider_deploying' from "Running Your Application Locally" and "Crud with Scaffolding".
2. Moved "Setting the Default Page" after "Crud with Scaffolding" (with routing discussion included).
3. Added 'consider_deploying' to the end of "Setting the Default Page".
4. Removed previous verbiage from PR #215 alerting to Heroku's 404 error. 

Please let me know if there are any additional changes I may make. 
