### PR TITLE
Adds rails_12factor gem for Heroku deploys.

### DIFF
--- a/sites/installfest/create_and_deploy_a_rails_app.step
+++ b/sites/installfest/create_and_deploy_a_rails_app.step
@@ -170,8 +170,10 @@ To this:
 group :development, :test do
   gem 'sqlite3'
 end
+
 group :production do
   gem 'pg'
+  gem 'rails_12factor'
 end
   RUBY
 

--- a/sites/installfest/get_a_sticker.step
+++ b/sites/installfest/get_a_sticker.step
@@ -192,12 +192,13 @@ gem 'sqlite3'
   message "Remove this line and replace it with:"
 
   source_code :ruby, <<-RUBY
-group :development do
+group :development, :test do
   gem 'sqlite3'
 end
 
 group :production do
   gem 'pg'
+  gem 'rails_12factor'
 end
   RUBY
 


### PR DESCRIPTION
Due to Rails 4.0 depreciating plugins, Heroku requires that you use the rails_12factor gem to properly handling logging and static asset serving on their platform now.
https://devcenter.heroku.com/articles/rails4-getting-started#heroku-gems

The gem does nothing on a Rails versions under 4.0, so it's safe to include in your Gemfile within the production stanza even with 3.2.x.  For simplicity sake, I updated the instructions on the installfest to include rails_12factor without having them check which rails version they are using.

If there are any other instance of instructions on how to setup a Gemfile for Heroku in other docs, they should also be updated accordingly.
