### PR TITLE
Corrections from railsbridge 20130727

### DIFF
--- a/sites/curriculum/curriculum.step
+++ b/sites/curriculum/curriculum.step
@@ -38,8 +38,8 @@ day... unless I really screwed something up. :D
 
 We're going to be working with:
 
-* ruby 1.9.3 installed via rvm (mac or linux) or RailsInstaller (windows)
-* rails 3.2.x
+* ruby 1.9.3 installed via rvm (mac or linux) or RailsInstaller (mac or windows)
+* rails 3.2.x or rails 4.0.x
 * bundler
 * sqlite
 * the text editor of your choice

--- a/sites/installfest/clean_up.step
+++ b/sites/installfest/clean_up.step
@@ -15,7 +15,7 @@ step "Delete the test_app from your computer" do
     message "Open your home directory and drag the test_app folder to the trash."
   end
   option "Linux" do
-    console "rm -rf ~/test_app"
+    console "rm -rf ~/railsbridge/test_app"
   end
 end 
 step "Delete the sticker app from your computer" do


### PR DESCRIPTION
  Wrong directory to rm -rf specified for linux clean up
  Rails 4 is valid too
  rails installer can install ruby on osx
