### PR TITLE
Changed test runner instructions to run under 'bundle exec' to match CI....

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then open <http://localhost:9292> in a web browser.
 
 If you make any changes, and especially before a pull request, run
 
-    bundle exec rspec
+    bundle exec rake spec
 
 which will run some unit tests and also do syntax validation on all pages, to make sure you didn't break anything.
 


### PR DESCRIPTION
... The tests were failing under the prior instructions.

This is small potatoes, but a few tests were failing for me with the old instructions but they were passing in TravisCI. Checking I see that Travis runs under 'bundle exec' and that does indeed pass at the command line. I could delve in to see why 'rake spec' is failing, if that is preferable.
