### PR TITLE
note about default welcome page not showing when deploying to Heroku and using Rails 4

### DIFF
--- a/sites/installfest/create_and_deploy_a_rails_app.step
+++ b/sites/installfest/create_and_deploy_a_rails_app.step
@@ -256,7 +256,7 @@ Migrating to CreateUsers (20111204065949)
 
     message "The URL for your app is <code>*application name*.heroku.com</code> -- so with the example output in the previous step, it would be <code>floating-winter-18.heroku.com</code>. Verify you see the welcome page. Leave this browser window open."
 
-    tip "If using <strong>Rails 4.0.x</strong>, further configuration is needed to get the welcome page to show on Heroku. You will get a message saying that 'The page you were looking for doesn't exist.' Do not worry about this for now."
+    tip "If using <strong>Rails 4.0.x</strong>, the default welcome page will not show on Heroku. You will get a message saying that 'The page you were looking for doesn't exist.' Do not worry about this for now."
 
     message "In the browser, add <code>/users</code> to the end of the URL and hit *enter*. Verify you see the user list page."
 


### PR DESCRIPTION
Some students using Rails 4 were confused at the last Railsbridge event when they hit the end of this step:
http://installfest.railsbridge.org/installfest/create_and_deploy_a_rails_app

Rails 4 doesn't show the Welcome Aboard default page on Heroku. It only shows it on localhost.

Please note that I only added line 259. Not sure why the commit says I edited line 183. I couldn't figure out how to make the commit without showing that line as edited.
