### PR TITLE
content for clone_a_repo

### DIFF
--- a/sites/javascript/clone_a_repo.step
+++ b/sites/javascript/clone_a_repo.step
@@ -1,4 +1,4 @@
-message <<- MARKDOWN
+message <<-MARKDOWN
 
 #Clone a Repo Contining HTML & CSS
 


### PR DESCRIPTION
Steps to get HTML & CSS files for the javascript workshop into the students' computer, via git or downloading zip files from GitHub or USB drive.

Links to the actual files should be included when they exist & are on the Railsbridge repository.
