### PR TITLE
Add a step to create a root route

### DIFF
--- a/sites/installfest/get_a_sticker.step
+++ b/sites/installfest/get_a_sticker.step
@@ -214,8 +214,27 @@ git commit -m "Add pg gem for Heroku."
 GIT_COMMIT
   result "[master 4a275be] Add pg gem for Heroku.
  2 files changed, 6 insertions(+)"
+ 
+ message "Use your editor to open the routes.rb  (`C:\\sites\\sticker\\config\\routes.rb` or `~/sticker/config/routes.rb`) and find the line containing:"
 
-  message "The name of your heroku app will be different. That is fine."
+  source_code :ruby, <<-RUBY
+# root 'welcome#index'
+  RUBY
+  
+ message "Remove this line and replace it with"
+ 
+ source_code :ruby, <<-RUBY
+root 'drinks#index'
+  RUBY
+  
+ message "Commit this change"
+ 
+ console <<-GIT_COMMIT
+git add .
+git commit -m "Changed root route"
+  GIT_COMMIT
+
+ message "The name of your heroku app will be different. That is fine."
 
   console "heroku create"
   result <<-HEROKU_CREATE


### PR DESCRIPTION
We (Tim the volunteer and I) discovered that rails 4.0 on heroku would throw an exception going to the index page if you did not have a root route defined. We considered two possibilities:

1) editing the routes file may be difficult for new users, but it solved the problem
2) leave the change within modifying the URL

However, having heroku open on an error page could be traumatic for new users. We chose option one which will assist new users in getting their app to work. 

We hope this makes it easier! 
