### PR TITLE
Add Missing Step

### DIFF
--- a/sites/curriculum/getting_started.step
+++ b/sites/curriculum/getting_started.step
@@ -1,4 +1,3 @@
-
 img src: "img/Start_page.png", alt: "Start Page"
 
 goals do
@@ -12,6 +11,11 @@ steps do
 
   step do
     switch_to_home_directory
+  end
+  
+  step do
+    console "mkdir railsbridge"
+    message "This command creates a new directory for us to store our project in."
   end
 
   step do


### PR DESCRIPTION
In the directions, we have "cd ~", followed by "cd railsbridge".  The students are getting directory not found.

This change adds a step after "cd ~" and before "cd railsbridge" to create that directory.
