### PR TITLE
Change `Topic.new(params[:topic])` to `Topic.new(topic_params)` 

### DIFF
--- a/sites/curriculum/redirect_to_the_topics_list_after_creating_a_new_topic.step
+++ b/sites/curriculum/redirect_to_the_topics_list_after_creating_a_new_topic.step
@@ -27,7 +27,7 @@ steps {
 
     source_code :ruby, <<-RUBY
 def create
-  @topic = Topic.new(params[:topic])
+  @topic = Topic.new(topic_params)
 
   respond_to do |format|
     if @topic.save


### PR DESCRIPTION
Noticed error in the ['Redirect to the Topics List...'](http://curriculum.railsbridge.org/curriculum/redirect_to_the_topics_list_after_creating_a_new_topic) page. It says to use `param[:topic]` instead of the user defined controller method to handle user input as required by strong parameters (`topic_params`). Since we're using Rails 4 these days with strong_parameters this is going to break and cause some confusion.
