### PR TITLE
Fix public key permission deny issue when ssh to Heroku

### DIFF
--- a/sites/installfest/create_an_ssh_key.step
+++ b/sites/installfest/create_an_ssh_key.step
@@ -49,6 +49,15 @@ verify do
     message "`id_rsa` is your **private key** and must be kept secret."
     message "If someone else gets your private key and your passphrase, then they can pretend to be you and log on to your Heroku or Github accounts and cause mischief!"
   end
+
+  message "Add your generated public key to the authentication agent using the following command:"
+
+  console "ssh-add ~/.ssh/id_rsa"
+
+  result <<-OUTPUT
+  Enter passphrase for /Users/student/.ssh/id_rsa:
+  Identity added: /Users/student/.ssh/id_rsa (/Users/student/.ssh/id_rsa)"
+    OUTPUT
 end
 
 end


### PR DESCRIPTION
Without adding the rsa public key to the authentication agent in a local machine, say Ubuntu, one would encounter the following error:

------Agent admitted failure to sign using the key.
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
