### PR TITLE
modified update to redirect_to topics_path to avoid bug: duplicate flash...

### DIFF
--- a/sites/curriculum/redirect_to_the_topics_list_after_creating_a_new_topic.step
+++ b/sites/curriculum/redirect_to_the_topics_list_after_creating_a_new_topic.step
@@ -1,11 +1,12 @@
 goals {
 
   message "
-  When a user creates a new topic they are currently shown a page with
-  just that topic. For our voting app it makes more sense that they
-  would be taken back to the topic list."
+  When a user creates a new topic, or edits an existing topic, they are 
+  currently shown a page with just that topic. For our voting app it makes
+  more sense that they would be taken back to the topic list."
 
-  goal "In this step we'll change the flow of our app so that the user is taken back to the topics list after they add a new topic."
+  goal "In this step we'll change the flow of our app so that the user is taken back to the topics list after they add a new topic (create) or 
+  edit an existing topic (update)."
 }
 
 steps {
@@ -40,6 +41,17 @@ def create
   end
 end
     RUBY
+
+message "In the same file, locate the update method. "
+
+    message "Find the line:"
+
+    source_code :ruby, "format.html { redirect_to @topic, notice: 'Topic was successfully updated.' }"
+
+
+    message 'and change `@topic` to `topics_path` like before:'
+
+    source_code :ruby, "format.html { redirect_to topics_path, notice: 'Topic was successfully updated.' }"
   end
 
   step "Add the flash message to your application view" do
@@ -65,8 +77,8 @@ explanation {
   message <<-MARKDOWN
   * `format.html { redirect_to topics_path, notice: 'Topic was successfully created.' }`:
     * `format.html` means that the server should send html back to the browser
-    * `redirect_to topics_path` means show the **topics list page** when we're done creating a topic
-    * `notice: 'Topic was successfully created.'` puts the message into the flash so it will be displayed on the topics list
+    * `redirect_to topics_path` means show the **topics list page** when we're done creating or updating a topic
+    * `notice: 'Topic was successfully created/updated.'` puts the message into the flash so it will be displayed on the topics list
   MARKDOWN
 }
 


### PR DESCRIPTION
... messages on show page

The instructions have the student change 'redirect_to @topic' to 'redirect_to topics_path' in the topics_controller#create method.  Then they are told to add a flash message to 'app/views/layouts/application.html.erb'.

After this, when doing an edit, the call to topics_controller#update still has 'redirect_to @topic', which goes to the show page.   In this view, there are now two copies of the flash message.   One from the show.html and one from the application.html.

Both edit and create should return to the topics_path, so I updated the instructions to have the student make both changes.   The bug in the show page is thus avoided.

Alternatively, the student could have been instructed to remove the duplicate flash message display lines from show.html, but changing both create and update to be symmetric seems more correct.

![screen shot 2013-10-20 at 8 50 16 pm](https://f.cloud.github.com/assets/5296952/1369663/ff812b0c-39fb-11e3-8a8c-c216358e3d2d.png)
