### PR TITLE
Add test for DVD in Titleizer

### DIFF
--- a/spec/titleizer_spec.rb
+++ b/spec/titleizer_spec.rb
@@ -13,6 +13,10 @@ describe Titleizer do
   it 'uppercases ssh' do
     Titleizer.title_for_page('ssh_into_all_the_things').should == 'SSH Into All The Things'
   end
+  
+  it 'uppercases dvd' do
+    Titleizer.title_for_page('why_cant_my_vhs_play_this_dvd').should == 'Why Cant My Vhs Play This DVD'
+  end
 
   it 'capitalizes sentences' do
     Titleizer.title_for_page('sandwich_parade_on_tuesday').should == 'Sandwich Parade On Tuesday'


### PR DESCRIPTION
There wasn't a test for the DVD case in Titleizer. I can't even believe that we made the titleizer uppercase DVD; I had go to back and check that the word DVD shows up in the TOC. Might be nice to make this a shared behavior test at this point though, no? The only thing you'd lose is the silly test strings.

Also, let it be known that @habutai is convinced this test is really dumb because VHS is not capitalized.
