### PR TITLE
Make sure ruby version is consistent with rails version

### DIFF
--- a/sites/installfest/osx_rvm.step
+++ b/sites/installfest/osx_rvm.step
@@ -59,10 +59,10 @@ verify "successful installation" do
   fuzzy_result "git version 1.{FUZZY}x.x{/FUZZY}"
 
   console "which ruby"
-  fuzzy_result "/Users/alex/.rvm/rubies/ruby-1.9{FUZZY}.3-p290{/FUZZY}/bin/ruby"
+  fuzzy_result "/Users/alex/.rvm/rubies/ruby-2{FUZZY}.0.0-p247{/FUZZY}/bin/ruby"
 
   console "which rails"
-  fuzzy_result "/Users/alex/.rvm/gems/ruby-1.9{FUZZY}.3-p290{/FUZZY}/bin/rails"
+  fuzzy_result "/Users/alex/.rvm/gems/ruby-2{FUZZY}.0.0-p247{/FUZZY}/bin/rails"
 end
 
 next_step "create_an_ssh_key"


### PR DESCRIPTION
This page instructs students to check to verify they've installed Rails 4, but then instructs them to check to see that they've installed Ruby 1.9.3. Rails 4 requires Ruby 2. 

I don't think it's super important that we decide on Rails 4/ Ruby 2 vs Rails 3 / Ruby 1.9.3, but it is important that these things are consistent. This prevents students from getting confused about conflicting versions.
