### PR TITLE
Add a max width for images.

### DIFF
--- a/public/css/doc_page.scss
+++ b/public/css/doc_page.scss
@@ -69,6 +69,7 @@ h1 {
 img {
   margin: auto;
   display: block; /* otherwise centering doesn't happen */
+  max-width: 100%;
 }
 
 .model-diagram {


### PR DESCRIPTION
Prevents overflows in docs
