### PR TITLE
Updated chrome dev tools language

### DIFF
--- a/sites/frontend/dev_tools.step
+++ b/sites/frontend/dev_tools.step
@@ -30,7 +30,7 @@ steps do
   end
   
   step do
-    message "The 'Script' panel is another JavaScript pro tool. If you're used to working with an IDE that has a debugger, you'll be able to use many of the same techniques (like breakpoints, stack traces, and watch expressions) right here in the browser."
+    message "The 'Sources' panel is another JavaScript pro tool. If you're used to working with an IDE that has a debugger, you'll be able to use many of the same techniques (like breakpoints, stack traces, and watch expressions) right here in the browser."
     message "<img src='img/devtools_script.png'>"
   end
 end


### PR DESCRIPTION
Changed chrome dev tools panel name 'Script' to 'Sources' to reflect change in chrome.  The annotated screenshot on the Dev Tools page should be to be changed to match.

Once again, I ran rake and got the following error (sorry, I'm a noob):

purple-unicorn:~/Dropbox/railsbridge/railsbridge_website naomi$ rake
/Users/naomi/.rvm/rubies/ruby-1.9.3-p125/bin/ruby -S rspec spec/app_spec.rb spec/contents_spec.rb spec/markdown_spec.rb spec/media_wiki_spec.rb spec/site_index_spec.rb spec/site_spec.rb spec/site_syntax_spec.rb spec/step_page_spec.rb spec/step_spec.rb spec/titleizer_spec.rb --format d --backtrace --color
/Users/naomi/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in `require': cannot load such file -- wrong/adapters/rspec (LoadError)
    from /Users/naomi/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:55:in`require'
    from /Users/naomi/Dropbox/railsbridge/railsbridge_website/spec/spec_helper.rb:6:in `<top (required)>'
    from /Users/naomi/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
    from /Users/naomi/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /Users/naomi/Dropbox/railsbridge/railsbridge_website/spec/app_spec.rb:1:in`<top (required)>'
    from /Users/naomi/.rvm/gems/ruby-1.9.3-p125/gems/rspec-core-2.14.4/lib/rspec/core/configuration.rb:896:in `load'
    from /Users/naomi/.rvm/gems/ruby-1.9.3-p125/gems/rspec-core-2.14.4/lib/rspec/core/configuration.rb:896:in`block in load_spec_files'
    from /Users/naomi/.rvm/gems/ruby-1.9.3-p125/gems/rspec-core-2.14.4/lib/rspec/core/configuration.rb:896:in `each'
    from /Users/naomi/.rvm/gems/ruby-1.9.3-p125/gems/rspec-core-2.14.4/lib/rspec/core/configuration.rb:896:in`load_spec_files'
    from /Users/naomi/.rvm/gems/ruby-1.9.3-p125/gems/rspec-core-2.14.4/lib/rspec/core/command_line.rb:22:in `run'
    from /Users/naomi/.rvm/gems/ruby-1.9.3-p125/gems/rspec-core-2.14.4/lib/rspec/core/runner.rb:80:in`run'
    from /Users/naomi/.rvm/gems/ruby-1.9.3-p125/gems/rspec-core-2.14.4/lib/rspec/core/runner.rb:17:in `block in autorun'
/Users/naomi/.rvm/rubies/ruby-1.9.3-p125/bin/ruby -S rspec spec/app_spec.rb spec/contents_spec.rb spec/markdown_spec.rb spec/media_wiki_spec.rb spec/site_index_spec.rb spec/site_spec.rb spec/site_syntax_spec.rb spec/step_page_spec.rb spec/step_spec.rb spec/titleizer_spec.rb --format d --backtrace --color failed
