### PR TITLE
Use titleizer on main page

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -176,7 +176,7 @@ class Step < Erector::Widget
     div class: 'site-desc' do
       h1 do
         a href: "/#{site_name}" do
-          text site_name.gsub(/[-_]/, ' ').split.map(&:capitalize).join(' ')
+          text Titleizer.title_for_page(site_name)
         end
       end
       div raw(md2html description)


### PR DESCRIPTION
This ensures that should you ever have a site whose name includes a special case, or uppercase word (e.g. "Introduction to RVM") it will correctly display, as is done in the drop-down menu.
