### PR TITLE
Update OS X fuzzy Ruby version number

### DIFF
--- a/sites/installfest/osx_rvm.step
+++ b/sites/installfest/osx_rvm.step
@@ -62,10 +62,10 @@ verify "successful installation" do
   fuzzy_result "git version 1.{FUZZY}x.x{/FUZZY}"
 
   console "which ruby"
-  fuzzy_result "/Users/alex/.rvm/rubies/ruby-{FUZZY}1.9.3-p290{/FUZZY}/bin/ruby"
+  fuzzy_result "/Users/alex/.rvm/rubies/ruby-{FUZZY}2.0.0-p247{/FUZZY}/bin/ruby"
 
   console "which rails"
-  fuzzy_result "/Users/alex/.rvm/gems/ruby-{FUZZY}1.9.3-p290{/FUZZY}/bin/rails"
+  fuzzy_result "/Users/alex/.rvm/gems/ruby-{FUZZY}2.0.0-p247{/FUZZY}/bin/rails"
 end
 
 next_step "configure_git"


### PR DESCRIPTION
Minor change: at the end of http://installfest.railsbridge.org/installfest/osx_rvm it shows an Approximate Expected Result  of `ruby 1.9.3-p290`, where earlier the docs walk you through installing 2.0.0.

This just updates the section at the end to expect 2.0.0.
