### PR TITLE
Remove reference to index.html in HINT

### DIFF
--- a/sites/intermediate-rails/create_a_new_rails_app_with_a_static_home_page.step
+++ b/sites/intermediate-rails/create_a_new_rails_app_with_a_static_home_page.step
@@ -28,7 +28,6 @@ end
 
 hints do
 message <<-MARKDOWN
-* You'll definitely want to delete the index.html that Rails provides. If you can't find it, ask your neighbor! 
 * If you have no idea what to put in your home controller, maybe try looking back at a past-Railsbridge app? Or another rails app you have lying about? 
 MARKDOWN
 end


### PR DESCRIPTION
This has been removed in rails 4, and mentioning this now seems to confuse people that haven't
had experience with rails 3.
