### PR TITLE
updated description of rake db:migrate

### DIFF
--- a/sites/en/intro-to-rails/creating_a_migration.step
+++ b/sites/en/intro-to-rails/creating_a_migration.step
@@ -36,7 +36,7 @@ explanation {
   message <<-MARKDOWN
 `rake` _(ruby make)_ is a tool that allows you to run small Ruby programs (**tasks**) that you use often in your application.
 
-Here, `rake db:migrate` is a task provided by the Rails framework. It creates a bunch of new files, including a *migration*, a *model*, a *view*, and a *controller*.
+Here, `rake db:migrate` is a task provided by the Rails framework. It uses the migration file we just created (`db/migrate/201xxxxxxxxxxx_create_topics.rb`) to change the database. Database migration files can be crucial to code collaboration.
 
   MARKDOWN
 


### PR DESCRIPTION
It seemed to be confusing the `scaffold` command with `db:migrate`
