### PR TITLE
fix root routing error in 'deploy a rails app'

### DIFF
--- a/sites/en/installfest/deploy_a_rails_app.step
+++ b/sites/en/installfest/deploy_a_rails_app.step
@@ -100,7 +100,7 @@ bundle install --without production
     message "Remove this line and replace it with:"
 
     source_code :ruby, <<-RUBY
-      root 'drinks#index'
+      root to: 'drinks#index'
     RUBY
 
     message "Note that you must remove the leading '#', as lines that start with a # are


### PR DESCRIPTION
The current guide says to set the root path by doing

root 'drinks#index'

Following the guide this will give the error "TypeError: no implicit conversion of String into Hash" when trying to perform db:migrate/rails s.  Also heroku will give this error when trying to compile assets along with migrating and such.
