### PR TITLE
Mention that the upvote method must go above the private keyword

### DIFF
--- a/sites/en/intro-to-rails/allow_people_to_vote.step
+++ b/sites/en/intro-to-rails/allow_people_to_vote.step
@@ -5,7 +5,7 @@ goals {
 steps {
 
   step "Add a new controller action for voting" do
-    message "Edit `app/controllers/topics_controller.rb` to add a method like this:"
+    message "Edit `app/controllers/topics_controller.rb` and add this method at the end of the controller, above the `private` keyword:"
 
     source_code :ruby, <<-RUBY
       def upvote


### PR DESCRIPTION
Several students were adding the `upvote` action method to the end of the controller under the private methods. The scaffold generator in recent versions of Rails added private methods to controllers.
