### PR TITLE
Escape URL by ERB::Util.u. 

### DIFF
--- a/lib/doc_page.rb
+++ b/lib/doc_page.rb
@@ -5,6 +5,7 @@ require 'erector_scss'
 require 'titleizer'
 require 'html5_page'
 require 'flags'
+require 'erb'
 
 class DocPage < Html5Page
   needs :site_name, :doc_title, :doc_path, :page_name, :src, :locale
@@ -124,8 +125,8 @@ class DocPage < Html5Page
         # Encode page name and fragment name separately so that
         # the fragment indicator '#' won't be escaped.
         page_name, fragment = @back.split('#')
-        url_components = [URI.escape(page_name, URI::PATTERN::RESERVED)]
-        url_components << URI.escape(fragment, URI::PATTERN::RESERVED) if fragment
+        url_components = [ERB::Util.u(page_name)]
+        url_components << ERB::Util.u(fragment) if fragment
         back_url = url_components.join('#')
 
         div.back {

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -4,6 +4,7 @@ require 'erector_scss'
 require 'markdown_renderer'
 require 'titleizer'
 require 'active_support/core_ext/string/strip'
+require 'erb'
 
 class Step < Erector::Widget
   external :style, <<-CSS
@@ -107,7 +108,7 @@ class Step < Erector::Widget
   end
 
   def _escaped str
-    URI.escape(str, URI::PATTERN::RESERVED)
+    ERB::Util.u(str)
   end
 
   def simple_link name, options={}


### PR DESCRIPTION
As I explained in rails-taiwan/railsbridge-docs#6, it seems that [`ERB::Util.url_encode`](http://ruby-doc.org/stdlib-2.1.2/libdoc/erb/rdoc/ERB/Util.html#method-c-url_encode) works great for non-ASCII and the `:` characters. I think we should migrate to it, although it requires ERB library.

Hopefully fixes the issues of broken `:` escaping after #353 was merged, which was reverted at 01ca022f14fd03095bfe49ba13ede55e82409f38.
