### PR TITLE
Update linux setup docs to reference Ubuntu 14.04

### DIFF
--- a/sites/en/installfest/linux.step
+++ b/sites/en/installfest/linux.step
@@ -52,7 +52,7 @@ end
 
 step "Install RVM" do
   important do
-    message "If you're using Ubuntu 12.04 or the latest version of Mint, ensure that the Run command as login shell option is checked under the Title and Command tab in Profile Preferences (located in Terminal's Edit menu). After changing this setting, you may need to exit your console session and start a new one before the changes take affect."
+    message "If you're using Ubuntu 12.04, Ubuntu 14.04 or the latest version of Mint, ensure that the Run command as login shell option is checked under the Title and Command tab in Profile Preferences (located in Terminal's Edit menu). After changing this setting, you may need to exit your console session and start a new one before the changes take affect."
     img src: 'img/railsbridge_ubuntu12-checkbox.png', alt: "Ubuntu 12.04 terminal settings"
   end
   insert "install_rvm"


### PR DESCRIPTION
added Ubuntu 14.04 to the versions of Ubuntu which require 'run command as login shell' set
