### PR TITLE
add instructions for email accounts

### DIFF
--- a/sites/en/installfest/create_a_heroku_account.step
+++ b/sites/en/installfest/create_a_heroku_account.step
@@ -7,7 +7,7 @@ end
 step "Create an account" do
   message "Click the big **Sign Up** button (it's about halfway down the page)"
   message "Enter your email address."
-  important "Use the same email address for heroku, git, github, and ssh."
+  important "Use the same email address for heroku, git, github, and ssh. Be sure to use an email account you can log into immediately."
 end
 
 step "Activate your account" do

--- a/sites/en/installfest/installfest.step
+++ b/sites/en/installfest/installfest.step
@@ -6,7 +6,7 @@ step "Prepare for the Installfest" do
 
 ## You must bring:
 
-* **Your laptop.** You need to have a working wifi connection and a browser.
+* **Your laptop.** You need to have a working wifi connection, a browser and an email account you can readily access.
   * If you have a choice between a Mac and a Windows laptop, please bring the Mac.
   * Linux is an acceptable alternative, but the Installfest is only tested on Ubuntu.
 * **Power cord for your laptop**


### PR DESCRIPTION
At each RailsBridge I've attended, there have been people who get to the Heroku account confirmation step and say that they can't access their email account. They may not know their password or it's a work account they can't access remotely, or for other reasons. I'm proposing this change so attendees will know they'll need to readily access their account to hopefully avoid this problem.
