### PR TITLE
Adding {FUZZY} to username in sample path

### DIFF
--- a/sites/en/installfest/osx_rvm.step
+++ b/sites/en/installfest/osx_rvm.step
@@ -62,10 +62,10 @@ verify "successful installation" do
   fuzzy_result "git version 1.{FUZZY}x.x{/FUZZY}"
 
   console "which ruby"
-  fuzzy_result "/Users/alex/.rvm/rubies/ruby-{FUZZY}2.0.0-p247{/FUZZY}/bin/ruby"
+  fuzzy_result "/Users/{FUZZY}alex{/FUZZY}/.rvm/rubies/ruby-{FUZZY}2.0.0-p247{/FUZZY}/bin/ruby"
 
   console "which rails"
-  fuzzy_result "/Users/alex/.rvm/gems/ruby-{FUZZY}2.0.0-p247{/FUZZY}/bin/rails"
+  fuzzy_result "/Users/{FUZZY}alex{/FUZZY}/.rvm/gems/ruby-{FUZZY}2.0.0-p247{/FUZZY}/bin/rails"
 end
 
 next_step "configure_git"


### PR DESCRIPTION
In the OS X RVM install directions, we've grayed out version numbers so that users won't be concerned with matching these exactly.

![screen shot 2014-09-28 at 8 40 02 pm](https://cloud.githubusercontent.com/assets/59535/4437140/94d474ee-478d-11e4-84e6-32f7ce58a5fa.png)

I suggest we do the same with `alex`, to reduce confusion.
