### PR TITLE
Explain syntax highlighting in Installfest docs

### DIFF
--- a/sites/en/installfest/deploy_a_rails_app.step
+++ b/sites/en/installfest/deploy_a_rails_app.step
@@ -79,6 +79,9 @@ step "Deploy your app to Heroku" do
 
     message "Save the file."
 
+    tip do
+      message 'When you saved the file, your text editor may have added colors to the code, much like the example above.  It recognizes the file contains Ruby, and will mark up different kinds of words with different colors. This is called "syntax highlighting", which makes it easier to read code.'
+    end
     tip "Why Sqlite (sqlite3) and PostgreSQL (pg)?" do
       message "SQLite and PostgreSQL are different kinds of databases.  We're using SQLite for our development and test environments because it's simple to install.  We're using PostgreSQL in our production environment because Heroku has done the hard work of installing it for us and it's more powerful than SQLite. We have seperate test, development and production databases by default in Rails."
     end
@@ -107,6 +110,7 @@ bundle install --without production
 
     message "Note that you must remove the leading '#', as lines that start with a # are
     comments and will not have any effect."
+
   end
 
   step "Add the changes to git" do


### PR DESCRIPTION
At the Oct. 3 Installfest in San Francisco, a student asked, "What are all these weird colors?" when she was reading the Gemfile example. I noticed we explain syntax highlighting in the Ruby curriculum; how about we do the same for the student's possibly first encounter with a code editor?

I copied the explanation of syntax highlighting from the Ruby curriculum, and mentioned that's what's creating the colors in the code sample. This might be a good place for a partial instead.
