### PR TITLE
deleted railsinstaller from mac install

### DIFF
--- a/sites/en/installfest/macintosh.step
+++ b/sites/en/installfest/macintosh.step
@@ -29,19 +29,9 @@ Below is an example.
 end
 
 step "Choose your instructions" do
-  
-  option "Yosemite/Mavericks" do
+
+  option "Yosemite/Mavericks/Mountain Lion/Lion/Snow Leopard" do
     link "osx_rvm"
-  end
-  option "Mountain Lion/Lion/Snow Leopard" do
-    option_half "RailsInstaller" do
-      message "RailsInstaller is an easy way to get up and running with Ruby and Rails on OSX. Try it first."
-      link "osx_railsinstaller"
-    end
-    option_half "Manually" do
-      message "If something went wrong with RailsInstaller, or you want to do things the 'long way', use these instructions."
-      link "osx_rvm"
-    end
   end
 
   option "Leopard/Tiger/Panther" do


### PR DESCRIPTION
Eliminated the option for RailsInstaller per the request of Bianca Rodrigues
