### PR TITLE
ruby 2.0.0 -> 2.1.3

### DIFF
--- a/sites/en/installfest/_install_ruby.step
+++ b/sites/en/installfest/_install_ruby.step
@@ -1,21 +1,21 @@
 console <<-BASH
-  rvm install 2.0.0
+  rvm install 2.1.5
 BASH
 
 message "This downloads and compiles Ruby, which takes a while."
 console <<-BASH
-  rvm use 2.0.0
-  rvm --default use 2.0.0
+  rvm use 2.1.5
+  rvm --default use 2.1.5
 BASH
 
 verify do
   console "ruby -v"
-  fuzzy_result "ruby 2.0.0{FUZZY}p247 (2013-06-27 revision 41674) [x86_64-darwin13.0.0]{/FUZZY}"
+  fuzzy_result "ruby 2.1.5{FUZZY}p273 (2014-11-13 revision 48405) [x86_64-darwin13.0]{/FUZZY}"
 end
 
 div do
   h1 "Troubleshooting"
-  important "If `rvm install 2.0.0` says `autoreconf was not found in the PATH`" do
+  important "If `rvm install 2.1.5` says `autoreconf was not found in the PATH`" do
     div do
       option_half "Mac OS" do
         console "brew install automake"
@@ -26,7 +26,7 @@ div do
       end
     end
 
-    message "Once that completes, retry `rvm install 2.0.0`"
+    message "Once that completes, retry `rvm install 2.1.5`"
   end
 end
 


### PR DESCRIPTION
A couple of people at this weekend's NYC RailsBridge event who were running MacOS Yosemite were having issues with ruby 2.0.0 segfaulting.  Upgrading to 2.1.3 fixes the issue, and for the purposes of the RailsBridge tutorials, 2.1.3 should be a drop-in replacement for 2.0.0.
