### PR TITLE
Change 'railbridge' to 'railsbridge' in header

### DIFF
--- a/sites/en/installfest/create_a_rails_app.step
+++ b/sites/en/installfest/create_a_rails_app.step
@@ -8,7 +8,7 @@ step "Change to your home directory" do
   insert 'switch_to_home_directory'
 end
 
-step "Create a railbridge directory" do
+step "Create a railsbridge directory" do
   console "mkdir railsbridge"
   message "`mkdir` stands for make directory (folder)."
   message "We've made a folder called `railsbridge`."


### PR DESCRIPTION
On the Installfest page for creating a Rails app, there's a header with a mild typo: "railbridge"