### PR TITLE
Minor flow changes on Intro to Rails > Getting Started

### DIFF
--- a/sites/en/intro-to-rails/getting_started.step
+++ b/sites/en/intro-to-rails/getting_started.step
@@ -25,7 +25,9 @@ steps do
   step do
     message "Check to see if you have any existing suggestotron apps from a previous workshop."
     console "ls"
-    message "That command will list the files in your railsbridge directory. If you have any old suggestotron apps in that list, you can remove them to prevent hiccups:"
+    message "`ls` stands for **l**i**s**t."
+    message "It lists the contents of the current directory."
+    message "If you have any old suggestotron apps in that list, you can remove them to prevent hiccups:"
     console "rm -rf suggestotron"
   end
 
@@ -39,12 +41,6 @@ steps do
     console "cd suggestotron"
     message "'cd' stands for change directory."
     message "'cd suggestotron' makes suggestotron our current directory."
-  end
-
-  step do
-    console "ls"
-    message "'ls' stands for 'list (stuff)'."
-    message "It shows you the contents of the current folder."
   end
 
   step do

--- a/sites/en/intro-to-rails/getting_started.step
+++ b/sites/en/intro-to-rails/getting_started.step
@@ -39,7 +39,6 @@ steps do
 
   step do
     console "cd suggestotron"
-    message "'cd' stands for change directory."
     message "'cd suggestotron' makes suggestotron our current directory."
   end
 

--- a/sites/en/intro-to-rails/getting_started.step
+++ b/sites/en/intro-to-rails/getting_started.step
@@ -35,6 +35,7 @@ steps do
     console "rails new suggestotron"
     message "'rails new' creates a new rails project with the name you give."
     message "In this case we told it to create a new project called `suggestotron`. We'll go into detail on what it created shortly."
+    message "This will print a lot of stuff to the screen and can take a while to finish."
   end
 
   step do


### PR DESCRIPTION
This makes some small changes on the Getting Started page:

- Explain `ls` before using it and don't explain it twice
- Don't repeat `cd` explanation twice
- Explain that `rails new` can take a while to run