### PR TITLE
Simplify `git add` and use `git status` more

### DIFF
--- a/sites/en/intro-to-rails/add_the_project_to_a_git_repo.step
+++ b/sites/en/intro-to-rails/add_the_project_to_a_git_repo.step
@@ -23,21 +23,10 @@ steps do
   end
 
   step do
-    console "git add ."
-    message "`git add .` tells git that you want to add the current directory (aka `.`) and everything under it to the repo."
-    tip "git add" do
-      message <<-MARKDOWN
-        With Git, there are usually many ways to do very similar things.
-
-        * `git add foo.txt` adds a file named `foo.txt`
-        * `git add .` adds all new files and changed files, but *keeps* files that you've deleted
-        * `git add -A` adds everything, including deletions
-
-        "Adding deletions" may sound weird, but if you think of a version control system as keeping
-        track of *changes*, it might make more sense. Most people use `git add .` but `git add -A`
-        can be safer. No matter what, `git status` is your friend.
-      MARKDOWN
-    end
+    console "git add -A"
+    message "`git add -A` tells git that you want to add **a**ll of your changes."
+    message "You can add individual files with `git add` followed by the filename instead of `-A`."
+    message "For example, `git add foo.txt` would just add the file `foo.txt`."
   end
 
   step do

--- a/sites/en/intro-to-rails/add_the_project_to_a_git_repo.step
+++ b/sites/en/intro-to-rails/add_the_project_to_a_git_repo.step
@@ -18,8 +18,7 @@ steps do
     console "git status"
 
     message "`git status` tells you everything git sees as modified, new, or missing."
-  message "The first time you run this, you should see a ton of stuff."
-  message "The second time you run this, you shouldn't see much of anything."
+    message "You should see a ton of stuff under `Untracked files`."
   end
 
   step do
@@ -30,10 +29,24 @@ steps do
   end
 
   step do
+    console "git status"
+
+    message "Now you should see a bunch of files listed under `Changes to be
+committed`."
+  end
+
+  step do
     console "git commit -m \"Added all the things\""
     message "`git commit` tells git to actually _do_ all things you've said you wanted to do."
     message "This is done in two steps so you can group multiple changes together."
     message "`-m \"Added all the things\"`  is just a shortcut to say what your commit message is. You can skip that part and git will bring up an editor to fill out a more detailed message."
+  end
+
+  step do
+    console "git status"
+
+    message "Now you should see something like `nothing to commit, working
+directory clean` which means you've committed all of your changes."
   end
 end
 

--- a/sites/en/intro-to-rails/deploying_to_heroku.step
+++ b/sites/en/intro-to-rails/deploying_to_heroku.step
@@ -46,10 +46,9 @@ end
   step "Commit the Gemfile changes" do
     message "There are now changes to Gemfile and Gemfile.lock that need to be committed before we can push to heroku."
     console <<-SHELL
-git add .
+git add -A
 git commit -m "Changed Gemfile for heroku"
     SHELL
-    tip "There is a period after the word add in the first line."
   end
 end
 
@@ -61,7 +60,7 @@ situation "Every time" do
     message "`git status` shows you any pending changes you've created. If it has no output, you're already ready to deploy! Otherwise..."
 
     console <<-SHELL
-git add .
+git add -A
 git commit -m "Some helpful message for your future self"
     SHELL
     message "Your commit message should reference whatever your outstanding changes are: something like 'added votes to the topics index'."


### PR DESCRIPTION
I really liked the note about the difference between `git add .` and `git add -A` but I doubt this distinction will be useful for people this early on. I think it would be best to just use `git add -A` since that matches more closely to what people are likely expecting.

I added some intermediate `git status` steps because it is hard to tell what the other commands do without seeing the effects. It also drives home the point that if you don't know what's going on, look at `git status` to find out.