### PR TITLE
removes extra set of parentheses in loading_items page

### DIFF
--- a/sites/en/javascript-to-do-list-with-react/loading_items.step
+++ b/sites/en/javascript-to-do-list-with-react/loading_items.step
@@ -68,9 +68,8 @@ succeeds. Add the following lines of code to the bottom of the LoadItems functio
 
     source_code :javascript, <<-JAVASCRIPT
       loadRequest.done(function(dataFromServer) {
-         items = dataFromServer.items
-         notifyComponents()
-        })
+        items = dataFromServer.items
+        notifyComponents()
       })
     JAVASCRIPT
 


### PR DESCRIPTION
Removes the extra set of parentheses from React docs that was causing errors for students.