### PR TITLE
Added troubleshooting message in osx_rvm installfest instructions

### DIFF
--- a/sites/en/installfest/_install_ruby.step
+++ b/sites/en/installfest/_install_ruby.step
@@ -8,6 +8,12 @@ console <<-BASH
   rvm --default use 2.2
 BASH
 
+important "If you have an older version of Ruby installed and receive the following error -- `Unknown ruby string (do not know how to handle): ruby-2.2`" do
+  div do
+    console "rvm get stable \nrvm use 2.2.0\nrvm --default use 2.2.0"
+  end
+end
+
 verify do
   console "ruby -v"
   fuzzy_result "ruby 2.2.0p0{FUZZY}p0 (2014-12-25 revision 49005) [x86_64-darwin13]{/FUZZY}"
@@ -29,4 +35,3 @@ div do
     message "Once that completes, retry `rvm install 2.2`"
   end
 end
-


### PR DESCRIPTION
for those with older versions of ruby previously installed that receive an error message from rvm.

Known rvm issue: https://github.com/wayneeseguin/rvm/issues/3244