### PR TITLE
Add token to command line images

### DIFF
--- a/sites/en/intro-to-rails/add_the_project_to_a_git_repo.step
+++ b/sites/en/intro-to-rails/add_the_project_to_a_git_repo.step
@@ -9,7 +9,7 @@ end
 steps do
 
   step do
-    console "git init"
+    console "$ git init"
 
     message "It doesn't look like anything really happened, but `git init`
 initialized a new repository in a hidden directory called `.git`."
@@ -17,14 +17,14 @@ initialized a new repository in a hidden directory called `.git`."
   end
 
   step do
-    console "git status"
+    console "$ git status"
 
     message "`git status` tells you everything git sees as modified, new, or missing."
     message "You should see a ton of stuff under `Untracked files`."
   end
 
   step do
-    console "git add ."
+    console "$ git add ."
     message "`git add .` tells git that you want to add the current directory (aka `.`) and everything under it to the repo."
     tip "git add" do
       message <<-MARKDOWN
@@ -42,20 +42,20 @@ initialized a new repository in a hidden directory called `.git`."
   end
 
   step do
-    console "git status"
+    console "$ git status"
 
     message "Now you should see a bunch of files listed under `Changes to be committed`."
   end
 
   step do
-    console "git commit -m \"Added all the things\""
+    console "$ git commit -m \"Added all the things\""
     message "`git commit` tells git to actually _do_ all things you've said you wanted to do."
     message "This is done in two steps so you can group multiple changes together."
     message "`-m \"Added all the things\"`  is just a shortcut to say what your commit message is. You can skip that part and git will bring up an editor to fill out a more detailed message."
   end
 
   step do
-    console "git status"
+    console "$ git status"
 
     message "Now you should see something like `nothing to commit, working directory clean` which means you've committed all of your changes."
   end

--- a/sites/en/intro-to-rails/getting_started.step
+++ b/sites/en/intro-to-rails/getting_started.step
@@ -12,34 +12,34 @@ steps do
   step do
     insert 'switch_to_home_directory'
   end
-  
+
   step do
-    console "mkdir railsbridge"
+    console "$ mkdir railsbridge"
     message "This command creates a new directory for us to store our project in."
   end
 
   step do
-    console "cd railsbridge"
+    console "$ cd railsbridge"
   end
 
   step do
     message "Check to see if you have any existing suggestotron apps from a previous workshop."
-    console "ls"
+    console "$ ls"
     message "`ls` stands for **l**i**s**t."
     message "It lists the contents of the current directory."
     message "If you have any old suggestotron apps in that list, you can remove them to prevent hiccups:"
-    console "rm -rf suggestotron"
+    console "$ rm -rf suggestotron"
   end
 
   step do
-    console "rails new suggestotron"
+    console "$ rails new suggestotron"
     message "`rails new` creates a new Rails project with the name you give."
     message "In this case we told it to create a new project called `suggestotron`. We'll go into detail on what it created shortly."
     message "This will print a lot of stuff to the screen and can take a while to finish."
   end
 
   step do
-    console "cd suggestotron"
+    console "$ cd suggestotron"
     message "`cd suggestotron` makes suggestotron our current directory."
   end
 

--- a/sites/en/intro-to-rails/ruby_language.step
+++ b/sites/en/intro-to-rails/ruby_language.step
@@ -8,22 +8,30 @@ goals do
 end
 
 steps do
+tip "When entering commands in the terminal, you don't have to retype the '$'"
+
   step do
     message "Type this in the terminal to start the Interactive Ruby Shell, a program which lets you try out Ruby code:"
 
-    console_without_message "irb"
+    console_without_message "$ irb"
 
     message "Yours might look different, but it should look something like this:"
 
-    console_without_message "irb(main):001:0>"
+    console_without_message "$ irb(main):001:0>"
+
+    message "You can type 'exit' in irb to get back to the command line"
   end
 
   step do
-    console_with_message "Next try some simple math that's built into Ruby. Type these lines into IRB:", "3 + 3\n7 * 6"
+    console_with_message "Next try some simple math that's built into Ruby. Type this line into IRB and hit 'Enter':", "3 + 3"
+
+    console_with_message "Hopefully irb responded with something like this", "=> 6"
+
+    message "The '=>' shows you how irb evaluated the statement you entered (In this case, 3 + 3 = 6)"
   end
 
   step do
-    message "**Variables** are names with values assigned to them."
+    message "**Variables** are names with values assigned to them. Type the following into irb:"
 
     console_without_message "my_variable = 5"
 
@@ -43,7 +51,7 @@ my_variable * 3
 
     console_without_message 'fruits = ["kiwi", "strawberry", "plum"]'
 
-    message "Here we're using the variable `fruits` to hold a collection of fruit names."
+    message "Here we're using the variable `fruits` to hold a collection of fruit names. Each item in an array is called an **element** of the array."
   end
 
   step do
@@ -52,7 +60,7 @@ fruits = fruits + ["orange"]
 fruits = fruits - ["kiwi"]
     RUBY
 
-    message "`+` and `-` are called operators. We can use them with the array of fruits just like we can use them with numbers."
+    message "`+` and `-` are called **operators**. We can use them with the array of fruits just like we can use them with numbers."
 
   end
 
@@ -65,7 +73,7 @@ fruits = fruits - ["kiwi"]
 fruits.class
 RUBY
 
-    message "These are the three data types introduced so far: **Fixnum** (numbers), **String** (text), and **Array** (lists)."
+    message "irb will return the three data types introduced so far: **Fixnum** (numbers), **String** (text), and **Array** (lists)."
   end
 
   step do

--- a/sites/en/intro-to-rails/ruby_language.step
+++ b/sites/en/intro-to-rails/ruby_language.step
@@ -8,7 +8,7 @@ goals do
 end
 
 steps do
-tip "When entering commands in the terminal, you don't have to retype the '$'"
+tip "When entering commands in the terminal as described below, you don't have to retype the symbol at the end of the command prompt (usually '$' for Mac OS). When running a command line program like **irb**, this symbol will change. Just type what comes after it in each step!"
 
   step do
     message "Type this in the terminal to start the Interactive Ruby Shell, a program which lets you try out Ruby code:"
@@ -17,23 +17,23 @@ tip "When entering commands in the terminal, you don't have to retype the '$'"
 
     message "Yours might look different, but it should look something like this:"
 
-    console_without_message "$ irb(main):001:0>"
+    console_without_message "irb(main):001:0>"
 
     message "You can type 'exit' in irb to get back to the command line"
   end
 
   step do
-    console_with_message "Next try some simple math that's built into Ruby. Type this line into IRB and hit 'Enter':", "3 + 3"
+    console_with_message "Next try some simple math that's built into Ruby. Type this line into IRB and hit 'Enter':", "> 3 + 3"
 
-    console_with_message "Hopefully irb responded with something like this", "=> 6"
+    console_with_message "Hopefully irb responded with something like this:", "=> 6"
 
-    message "The '=>' shows you how irb evaluated the statement you entered (In this case, 3 + 3 = 6)"
+    message "The '=>' shows you how irb **evaluated** the statement you entered (In this case, 3 + 3 = 6)"
   end
 
   step do
     message "**Variables** are names with values assigned to them. Type the following into irb:"
 
-    console_without_message "my_variable = 5"
+    console_without_message "> my_variable = 5"
 
     message "This assigns the value `5` to the name `my_variable`."
   end
@@ -41,23 +41,23 @@ tip "When entering commands in the terminal, you don't have to retype the '$'"
   step do
     message "You can also do math with variables:"
     console_without_message <<-RUBY
-my_variable + 2
-my_variable * 3
+> my_variable + 2
+> my_variable * 3
     RUBY
   end
 
   step do
     message "Variables can also hold more than one value. This is called an **array**."
 
-    console_without_message 'fruits = ["kiwi", "strawberry", "plum"]'
+    console_without_message '> fruits = ["kiwi", "strawberry", "plum"]'
 
     message "Here we're using the variable `fruits` to hold a collection of fruit names. Each item in an array is called an **element** of the array."
   end
 
   step do
     console <<-RUBY
-fruits = fruits + ["orange"]
-fruits = fruits - ["kiwi"]
+> fruits = fruits + ["orange"]
+> fruits = fruits - ["kiwi"]
     RUBY
 
     message "`+` and `-` are called **operators**. We can use them with the array of fruits just like we can use them with numbers."
@@ -68,9 +68,9 @@ fruits = fruits - ["kiwi"]
     message "Everything in Ruby has a **class**. Type this into IRB:"
 
     console_without_message <<-RUBY
-7.class
-"kiwi".class
-fruits.class
+> 7.class
+> "kiwi".class
+> fruits.class
 RUBY
 
     message "irb will return the three data types introduced so far: **Fixnum** (numbers), **String** (text), and **Array** (lists)."
@@ -80,27 +80,27 @@ RUBY
     message "Each class has different **methods** that can be used on **instances** of that class."
 
     console_without_message <<-RUBY
-fruits.length
-fruits.first
+> fruits.length
+> fruits.first
     RUBY
 
     message "You can see all the methods available for an object:"
     console_without_message <<-RUBY
-fruits.methods
+> fruits.methods
     RUBY
 
     message "And **chain** methods together:"
     console_without_message <<-RUBY
-fruits.methods.sort
+> fruits.methods.sort
     RUBY
   end
 
   step do
     message "Arrays have a method called **each** which iterates through the list running code on each item."
     console_without_message <<-RUBY
-fruits.each do |fruit|
-  puts fruit
-end
+> fruits.each do |fruit|
+>  puts fruit
+> end
     RUBY
     message "This takes the first item from the `fruits` array (`\"strawberry\"`), assigns it to the variable `fruit`, and runs the code between `do` and `end`. Then it does the same thing for each other item in the list. The code above should print a list of the fruits."
   end
@@ -109,9 +109,9 @@ end
     message "A **conditional** runs code only when a statement evaluates to true."
 
     console_without_message <<-RUBY
-if my_variable > 1
-  puts "YAY!"
-end
+> if my_variable > 1
+>  puts "YAY!"
+> end
     RUBY
 
     message "This prints `YAY!` if the value stored in `my_variable` is greater than 1."
@@ -121,21 +121,21 @@ end
     message "If you want to do something else when the statement evaluates to false, you can use an `else`:"
 
     console_without_message <<-RUBY
-if my_variable > 1
-  puts "YAY!"
-else
-  puts "BOO!"
-end
+> if my_variable > 1
+>  puts "YAY!"
+> else
+>  puts "BOO!"
+> end
     RUBY
   end
 
   step do
     message "You can also make your own methods:"
     console_without_message <<-RUBY
-def pluralize(word)
-  word + "s"
-end
-pluralize("kiwi")
+> def pluralize(word)
+>  word + "s"
+> end
+> pluralize("kiwi")
     RUBY
 
     message "Methods take **parameters**, which are the variables they work on. In this case, we made a method called pluralize that takes one parameter, a word."
@@ -146,16 +146,16 @@ pluralize("kiwi")
   step do
     message "Putting it all together, let's make a method that says your opinion of some fruits:"
     console_without_message <<-RUBY
-def my_opinion(fruits)
-  fruits.each do |fruit|
-    if fruit == "pizza"
-      puts "pizza is the best!!!"
-    else
-      puts pluralize(fruit) + " are pretty good, I guess..."
-    end
-  end
-end
-my_opinion(["apple", "pizza", "orange"])
+> def my_opinion(fruits)
+>  fruits.each do |fruit|
+>    if fruit == "pizza"
+>      puts "pizza is the best!!!"
+>    else
+>      puts pluralize(fruit) + " are pretty good, I guess..."
+>    end
+>  end
+> end
+> my_opinion(["apple", "pizza", "orange"])
     RUBY
 
     message "Try changing this method to say what your favorite fruit is."


### PR DESCRIPTION
During our last workshop, many students got tripped up by entering commands into the terminal tab that had the Sinatra server running. This change adds a tip at the beginning of the intro to rails section explaining the command prompt symbol, and adds it to the command line images in the following steps. This has the added benefit of making copy and paste difficult for multi-line steps.