### PR TITLE
Modified Create a Github Account instructions

### DIFF
--- a/sites/en/installfest/create_a_github_account.step
+++ b/sites/en/installfest/create_a_github_account.step
@@ -33,9 +33,9 @@ step "Set up SSH authentication with GitHub" do
     BASH
 
     message "Windows users,"
-    console "clip < ~/.ssh/id_rsa.pub"
+    console "clip < \"%userprofile%\\.ssh\\id_rsa.pub\""
 
-  message "Now that you have copied the key you can add it to the GitHub account you created earlier."
+  message "Now that you have copied the key to your clipboard, you can add it to the GitHub account you created earlier."
 
   h1 "Add your SSH key to GitHub"
 
@@ -53,6 +53,8 @@ end
 step "Confirm SSH Authentification" do
 
   message "Confirm that you have successfully set up SSH Authentication for GitHub"
+
+  message "Windows users cannot perform this step."
 
   console "ssh -T git@github.com"
 


### PR DESCRIPTION
Changed instructions for Windows users to submit a key to Github.

`clip < ~/.ssh/id_rsa.pub` Does not work in windows, as `~/` is not a valid Windows path. Replaced it with `clip < %userprofile%\ssh\id_rsa.pub`, which is the correct way to reference the user directory path.

Also added a note stating that Windows Users cannot perform the SSH key verification process.  Windows does not come with an SSH client, and having a user install something like PuTTY just to verify a key.

This fixes the issues in the documentation now, but probably worth discussing is if Windows users should go through the trouble of setting up a SSH key at all or if they should just use HTTPS instead.

All tests pass, and the instructions have been checked locally.