### PR TITLE
Fixed spelling error in create a heroku account closes issue #446

### DIFF
--- a/sites/en/installfest/create_a_github_account.step
+++ b/sites/en/installfest/create_a_github_account.step
@@ -43,14 +43,14 @@ step "Set up SSH authentication with GitHub" do
 
   message "On the account setting page, select **SSH Keys** from the column on the left."
 
-  message "At the top right of this page, clik the button that says **Add SSH key**. In the title field, give a name for your SSH key, you might call it **My PC** or **Personal MacBook**. In the key field, paste the key you copied."
+  message "At the top right of this page, click the button that says **Add SSH key**. In the title field, give a name for your SSH key, you might call it **My PC** or **Personal MacBook**. In the key field, paste the key you copied."
 
   message "Click **Add Key**"
 
   message "Confirm the action by providing your GitHub Password"
 end
 
-step "Confirm SSH Authentification" do
+step "Confirm SSH Authentication" do
 
   message "Confirm that you have successfully set up SSH Authentication for GitHub"
 

--- a/sites/en/installfest/create_a_heroku_account.step
+++ b/sites/en/installfest/create_a_heroku_account.step
@@ -34,7 +34,7 @@ step "Add your SSH key to your Heroku account" do
 end
 
 section 'GitHub' do
-  message "Since by now you sould have both Git and an SSH key, you can optionally [Create a Github account](create_a_github_account) to share code with your friends."
+  message "Since by now you should have both Git and an SSH key, you can optionally [Create a Github account](create_a_github_account) to share code with your friends."
 end
 
 next_step "create_a_rails_app"

--- a/sites/en/installfest/create_a_rails_app.step
+++ b/sites/en/installfest/create_a_rails_app.step
@@ -27,7 +27,7 @@ step "Create a new Rails app" do
   console "cd test_app"
   console "rails server"
 
-  tip "In Windows, you may need to let Ruby and Rails communicate through your firewall.  Say yes to the popup."
+  tip "In Windows, you may need to let Ruby and Rails communicate through your firewall.  Say yes to the pop up."
 
   tip "Shortcut: Just type 'rails s'" do
     message <<-MARKDOWN

--- a/sites/en/installfest/editors.step
+++ b/sites/en/installfest/editors.step
@@ -5,7 +5,7 @@ There are a number of different editors designed for programming. You may alread
 * <a href="http://www.sublimetext.com/" target="_blank">Sublime Text</a> is popular with many Ruby and Rails users. You can use it free for evaluation, then must pay to continue using it.
 * <a href="http://komodoide.com/download/" target="_blank">Komodo</a> is a very good free programming editor, that is not used as widely as in the past. It is relatively easy to use.
 * <a href="http://macromates.com/" target="_blank">TextMate</a> is very popular in the Ruby and Rails community. It is not free.
-* <a href="https://atom.io/" target="_blank">Atom</a> is a free, open-source editor that can be customized with HTML, CSS, and JavaScript. A download is available for OSX 10.8+, Windows 7/8, and Ubuntu/RedHat linux.
+* <a href="https://atom.io/" target="_blank">Atom</a> is a free, open-source editor that can be customized with HTML, CSS, and JavaScript. A download is available for OS X 10.8+, Windows 7/8, and Ubuntu/RedHat linux.
 * <a href="http://aptana.com/products/studio3" target="_blank">Aptana Studio</a> is a free, full-featured, development IDE (Integrated Development Environment) for Ruby and Rails. It has many powerful features to assist you while you develop your code. You can install Aptana as either a stand-along program or as an <a href="https://www.eclipse.org/downloads/" target="_blank">Eclipse</a> plugin.
 * <a href="http://www.jetbrains.com/ruby/" target="_blank">RubyMine</a> is used by many companies for their Ruby and Rails software development. Is is also a full-featured IDE, very similar to Aptana. RubyMine is not free, but has a 30-day evaluation period.
 

--- a/sites/en/installfest/install_xcode_from_dvd.step
+++ b/sites/en/installfest/install_xcode_from_dvd.step
@@ -11,13 +11,13 @@ end
 step "Keep on clicking..." do
  li 'Click "Continue" at the Introduction screen.'
  li 'Click "Continue" at the License screen.'
- li 'Click "Agree" in the popup to agree to the license.'
+ li 'Click "Agree" in the pop up to agree to the license.'
  li 'Click "Continue" at the Destination Select screen.'
  li "Click \"Continue\" at the Installation Type screen. (Don't change the checkboxes.)"
 end
 
 step 'Click "Install".' do
- message "Enter your user password in the popup to REALLY start installing. It takes a while."
+ message "Enter your user password in the pop up to REALLY start installing. It takes a while."
 end
 
 step 'Click "Close"' do

--- a/sites/en/installfest/linux.step
+++ b/sites/en/installfest/linux.step
@@ -8,7 +8,7 @@ MARKDOWN
 
 step "Install packaged software and libraries" do
   message <<-MARKDOWN
-Open a terminal (Applications > Accessories > Terminal).  You may want to right-click on the terminal icon and select "Add to panel" so the icon will appear next to the default help and firefox icons in the top panel.
+Open a terminal (Applications > Accessories > Terminal).  You may want to right-click on the terminal icon and select "Add to panel" so the icon will appear next to the default help and Firefox icons in the top panel.
   MARKDOWN
 
   apts = %w{

--- a/sites/en/installfest/macintosh.step
+++ b/sites/en/installfest/macintosh.step
@@ -35,6 +35,6 @@ step "Choose your instructions" do
   end
   option "Earlier than Snow Leopard" do
     important "You should try upgrading to at least **Snow Leopard**. Apple doesn't sell it the Apple store anymore, so you'll have to [buy it from them online](http://store.apple.com/us/product/MC573Z/A/mac-os-x-106-snow-leopard) or find a copy from a friend."
-    message "It may be possible to get Ruby and Rails installed if your OS is older than Snow Leopard, but you're likely to encounter a lot of tough roadblocks that will require some intense googling."
+    message "It may be possible to get Ruby and Rails installed if your OS is older than Snow Leopard, but you're likely to encounter a lot of tough roadblocks that will require some intense Googling."
   end
 end

--- a/sites/en/installfest/windows.step
+++ b/sites/en/installfest/windows.step
@@ -94,7 +94,7 @@ step "Open a Terminal" do
 end
 
 step "Update RubyGems" do
-  message "The version of RubyGems that comes with Railsinstaller has some problems. Follow these steps to upgrade it!"
+  message "The version of RubyGems that comes with RailsInstaller has some problems. Follow these steps to upgrade it!"
 
   step "Check to see if you need to update" do
     console "gem -v"


### PR DESCRIPTION
Fixes misspelling from issue #446.

Ran all of installfest docs through a spell checker. Fixed all spelling errors and made some minor style corrections.

All tests pass, manually checked locally. 