### PR TITLE
Update `heroku version` result

### DIFF
--- a/sites/en/installfest/create_a_heroku_account.step
+++ b/sites/en/installfest/create_a_heroku_account.step
@@ -22,7 +22,10 @@ step "Install the Heroku toolbelt" do
 
   verify do
     console "heroku version"
-    result "2.26.7 or higher"
+    fuzzy_result <<-TEXT
+      heroku-toolbelt/{FUZZY}3.30.6 (x86_64-darwin10.8.0) ruby/1.9.3{/FUZZY}
+      {FUZZY}You have no installed plugins.{/FUZZY}
+    TEXT
   end
   message "Windows users, if `heroku version` doesn't work, open a new terminal window after the heroku installer has finished."
 end


### PR DESCRIPTION
In the install fest, a lot of students were confused about the output of `heroku version`. Specifically the presence of a second line "You have no plugins installed" seemed to cause a lot of confusion.