### PR TITLE
Fix Installfest link from Ruby home page

### DIFF
--- a/sites/en/ruby/ruby.step
+++ b/sites/en/ruby/ruby.step
@@ -20,7 +20,7 @@ We're going to be working with:
 * A text editor of your choice
 
 Everything should be set up the night before during our
-<a href="http://installfest.railsbridge.org/installfest">Installfest</a>. Please
+<a href="/installfest">Installfest</a>. Please
 ensure you have everything working _before_ you show up for the workshop.
 
 You can verify that you have everything working by trying this out in your terminal:

--- a/sites/en/ruby/ruby.step
+++ b/sites/en/ruby/ruby.step
@@ -20,7 +20,7 @@ We're going to be working with:
 * A text editor of your choice
 
 Everything should be set up the night before during our
-<a href="http://www.railsbridgeboston.org/installfest">Installfest</a>. Please
+<a href="http://installfest.railsbridge.org/installfest">Installfest</a>. Please
 ensure you have everything working _before_ you show up for the workshop.
 
 You can verify that you have everything working by trying this out in your terminal:


### PR DESCRIPTION
Currently, the Installfest link on the [Ruby page](http://docs.railsbridge.org/ruby/) links to http://www.railsbridgeboston.org/installfest which is not working right now (returning a 404)

All other Installfest links use a relative `/installfest` or http://installfest.railsbridge.org/installfest.

This updates this link to be consistent with the rest of the docs.

```
$ curl -i http://www.railsbridgeboston.org/installfest
HTTP/1.1 404 Not Found 
Connection: keep-alive
Content-Type: text/html
Cache-Control: public, max-age=300
Vary: Accept-Encoding
Server: WEBrick/1.3.1 (Ruby/2.1.0/2013-12-25)
Date: Sun, 12 Apr 2015 21:52:12 GMT
Content-Length: 14
Via: 1.1 vegur

File not found
```