### PR TITLE
Users need to exit IRB

### DIFF
--- a/sites/en/intro-to-rails/ruby_language.step
+++ b/sites/en/intro-to-rails/ruby_language.step
@@ -155,4 +155,6 @@ my_opinion(["apple", "pizza", "orange"])
   end
 end
 
+important "Before you move on to the next step you must exit IRB by typing 'exit'"
+
 next_step "getting_started"


### PR DESCRIPTION
Students are not exiting IRB before moving to the next step. Inserted important message to let them know they have to exit IRB before moving to the next step.