### PR TITLE
Installfest help

### DIFF
--- a/sites/en/installfest/_switch_to_home_directory.step
+++ b/sites/en/installfest/_switch_to_home_directory.step
@@ -1,5 +1,7 @@
 message "`cd` stands for change directory."
 
+message "If you are still in `irb`, type `quit` to exit."
+
 div do
   option_half "Windows" do
     console "cd c:\\Sites"

--- a/sites/en/installfest/configure_the_windows_terminal.step
+++ b/sites/en/installfest/configure_the_windows_terminal.step
@@ -1,4 +1,8 @@
 step "Configure the Windows Terminal" do
+  tip do
+    message "Make sure that you have the **Command Prompt with Ruby and Rails** open, not just the usual Windows Terminal. To open the special Terminal, choose **All Programs** on the Start menu, then choose **RailsInstaller** and then **Command Prompt with Ruby and Rails**."
+  end
+
   message "Right-click on the menu bar and select **Properties**"
 
   message "Under the *Options* tab, check the box for **QuickEdit Mode**. This will let you visually cut and paste."


### PR DESCRIPTION
Two things we found that sometimes tripped attendees up:

* not exiting `irb` before continuing;
* usual the regular Windows prompt rather than the fancy one.

This PR suggests adding reminders for these two things.