### PR TITLE
Intro to rails help

### DIFF
--- a/sites/en/intro-to-rails/getting_started.step
+++ b/sites/en/intro-to-rails/getting_started.step
@@ -55,7 +55,11 @@ steps do
   step do
     message <<-MARKDOWN
 Open the suggestotron folder as a project in your text editor.
+  MARKDOWN
 
+  tip "Close any files that are already open. They might be from yesterday's `test_app`, and we want to make sure that we're editing files in today's `suggestotron` app."
+
+  message <<-MARKDOWN
 In **Sublime Text 2**, you can use the `Project > Add Folder to Project...` menu option:
 
 ![Sublime Text Project menu screenshot](img/sublime_add_folder_to_project.png)

--- a/sites/en/intro-to-rails/running_your_application_locally.step
+++ b/sites/en/intro-to-rails/running_your_application_locally.step
@@ -5,13 +5,15 @@ end
 
 steps do
   step do
+    message "Make sure that you're in the `suggestotron` folder. You can type `pwd` (**p**rint **w**orking **d**irectory) in the terminal to see what folder you are in."
+
     console "rails server"
     message "This will print some stuff and stay running forever, printing more stuff
 every time you visit a page in your app."
   end
   step do
     text "Point your web browser to "
-    url "http://localhost:3000" 
+    url "http://localhost:3000"
     message "See your web app actually running!"
   end
 

--- a/sites/en/intro-to-rails/setting_the_default_page.step
+++ b/sites/en/intro-to-rails/setting_the_default_page.step
@@ -16,7 +16,7 @@ steps {
   step "Add a root route" do
     message "Open the file `config/routes.rb` in an editor (In the InstallFest yesterday, we suggested that you install and use **Sublime Text** as your editor)."
 
-    message "Search the file for **root**, it should be near the top if you are using Rails 4."
+    message "Search the file for **root**, it should be near the top if you are using Rails 4. You can use Sublime Text's search: look for **Find...** in the **Find** menu."
 
     message "Uncomment the line that contains the example command by removing the `#` sign in front of it, and change it to read `root 'topics#index'`. When you are done the line should look like this:"
 

--- a/sites/en/intro-to-rails/setting_the_default_page.step
+++ b/sites/en/intro-to-rails/setting_the_default_page.step
@@ -14,7 +14,7 @@ goals {
 steps {
 
   step "Add a root route" do
-    message "Open the file `config/routes.rb` in an editor."
+    message "Open the file `config/routes.rb` in an editor (In the InstallFest yesterday, we suggested that you install and use **Sublime Text** as your editor)."
 
     message "Search the file for **root**, it should be near the top if you are using Rails 4."
 


### PR DESCRIPTION
A few things we found that tripped people up during the course.

* People skipped the [Clean Up](https://docs.railsbridgecapetown.org/installfest/clean_up) steps of the InstallFest, which sometimes leads to editing `test_app` instead of `suggestotron`.
* People knew *what thing did what* of editor, terminal, and browser, but weren't always sure of the naming (i.e. that **Sublime** was the **editor**).
* On the "Add a root route" step, the default route is commented out and the (usually useful) syntax highlighting hides it a bit, meaning people sometimes miss it.
* Running commands sometimes had no effect. Sometimes this was because the commands weren't being run in the correct directory.

This PR attempts to fix these things.