### PR TITLE
Windows Gotchas - SSH-Agent Issue and Cleanup Command

### DIFF
--- a/sites/en/installfest/clean_up.step
+++ b/sites/en/installfest/clean_up.step
@@ -9,7 +9,9 @@ end
 
 step "Delete the test_app from your computer" do
   option "Windows" do
-    message "From the Explorer, right click on the test_app folder (inside C:\\Sites) and choose Delete."
+    message "From the Explorer, right click on the test_app folder (inside C:\\Sites\\railsbridge) and choose Delete."
+    message " - or - "
+    console_with_message "From the command prompt, run the following command:", "rmdir /s /q c:\\Sites\\railsbridge\\test_app"
   end
   option "Mac" do
     message "Open your home directory and drag the test_app folder to the trash."
@@ -17,5 +19,4 @@ step "Delete the test_app from your computer" do
   option "Linux" do
     console "rm -rf ~/railsbridge/test_app"
   end
-end 
-
+end

--- a/sites/en/installfest/create_an_ssh_key.step
+++ b/sites/en/installfest/create_an_ssh_key.step
@@ -73,7 +73,16 @@ The key fingerprint is:
 Enter passphrase for /Users/student/.ssh/id_rsa:
 Identity added: /Users/student/.ssh/id_rsa (/Users/student/.ssh/id_rsa)"
   OUTPUT
+
+  tip "Could not open a connection to your authentication agent" do
+    message "If the ssh-agent is not running, you will come across this error.  Here are a few commands that you can try to use to start the ssh-agent:"
+    console_with_message "For some Windows machines:", "eval `ssh-agent -s`"
+    console_with_message "For others (confirmed on some Windows 7, 8, 8.1, and 10 setups):", "eval $(ssh-agent)"
+    console_with_message "For Linux:", "eval `ssh-agent`"
+    message <<-MARKDOWN
+    <p>For additional options, this StackOverflow thread has been helpful: <a href="    http://stackoverflow.com/questions/17846529/could-not-open-a-connection-to-your-authentication-agent">    http://stackoverflow.com/questions/17846529/could-not-open-a-connection-to-your-authentication-agent</a></p>
+     MARKDOWN
+  end
 end
 
 next_step 'create_a_heroku_account'
-


### PR DESCRIPTION
* Adding notes (including a link to StackOverflow) for commands to start the ssh-agent if ssh-add fails
* Adding command for cleaning up the test_app from the command line in Windows.