### PR TITLE
Adding some text to clarify which directory user should be in before adding to local git repo for Linux Installfest step 2.4

### DIFF
--- a/sites/en/installfest/deploy_a_rails_app.step
+++ b/sites/en/installfest/deploy_a_rails_app.step
@@ -115,6 +115,8 @@ bundle install --without production
 
   step "Add the changes to git" do
 
+    message "Before running the following command \(to add to your local git repository\), make sure that you are in the correct directory: `~/.railsbridge/test_app`"
+
     console <<-BASH
       git add .
       git commit -m "Updates for heroku deployment"


### PR DESCRIPTION
This is a fix for this issue that I submitted: https://github.com/railsbridge/docs/issues/501 

I looked at the change in a local deploy (screenshot attached) 
![local_deploy](https://cloud.githubusercontent.com/assets/4776996/9828886/1cb84a50-58ba-11e5-9f8f-6f481df4a964.png)
and also did bundle rake exec and there were no failures. I'm not very familiar with step files so please let me know if you have feedback. 