### PR TITLE
Update node version for node/io merge

### DIFF
--- a/sites/en/installfest/windows.step
+++ b/sites/en/installfest/windows.step
@@ -129,7 +129,7 @@ step "Install Node.js" do
   message "Once your computer is back up, load **Command Prompt with Ruby and Rails** and..."
 
   console "node -v"
-  fuzzy_result "v0{FUZZY}.8.x{/FUZZY}"
+  fuzzy_result "v4{FUZZY}.x.x{/FUZZY}"
 end
 
 step "Update Rails" do


### PR DESCRIPTION
After *the big merge*, [Node's version number has bumped to 4](https://nodejs.org/en/blog/release/v4.0.0/).

> Current Version: v4.1.0