### PR TITLE
Add class context to first index method example in job boards

### DIFF
--- a/sites/en/job-board/make_a_jobs_home_page.step
+++ b/sites/en/job-board/make_a_jobs_home_page.step
@@ -89,8 +89,10 @@ MARKDOWN
 
 source_code_with_message "Add the index method to the controller:", :ruby,
 <<-RUBY
+class JobsController < ApplicationController
   def index
   end
+end
 RUBY
 
 message "And refresh <http://localhost:3000/jobs>"


### PR DESCRIPTION
We had several students who were new to programming or just new to Ruby who mistakenly put the first index method outside the class definition in a recent Sacramento RailsBridge.  They were pretty confused until they eventually checked in with TAs on why things weren't working.  This just adds the class index method in the context of the class.