### PR TITLE
Clarify installfest as requirement

### DIFF
--- a/sites/en/docs/docs.step
+++ b/sites/en/docs/docs.step
@@ -5,7 +5,7 @@ MARKDOWN
 h1 'Setup'
 
 site_desc 'installfest', <<-MARKDOWN
-Instructions for installing Ruby and Rails on your computer. You need to complete this before starting a Rails workshop!
+Instructions for installing Ruby and Rails on your computer. You need to complete these steps before starting a Rails workshop!
 MARKDOWN
 
 h1 'Rails'

--- a/sites/en/docs/docs.step
+++ b/sites/en/docs/docs.step
@@ -5,7 +5,7 @@ MARKDOWN
 h1 'Setup'
 
 site_desc 'installfest', <<-MARKDOWN
-Instructions for installing Ruby and Rails on your computer. You are required to do this before going to a Rails workshop!
+Instructions for installing Ruby and Rails on your computer. You need to complete this before starting a Rails workshop!
 MARKDOWN
 
 h1 'Rails'


### PR DESCRIPTION
One of our attendees read

> You are required to do this before going to a Rails workshop!

to mean that they must do it **before arriving at the workshop** rather than do as the first thing when they arrive.

The confusion could just come from the fact that we are doing an unusual one day thing this time, but it might be nice to clarify what we mean?