### PR TITLE
Remove (duplicate) notice step

### DIFF
--- a/sites/en/intro-to-rails/redirect_to_the_topics_list_after_creating_a_new_topic.step
+++ b/sites/en/intro-to-rails/redirect_to_the_topics_list_after_creating_a_new_topic.step
@@ -55,19 +55,6 @@ message "In the same file, locate the update method. "
     source_code :ruby, "format.html { redirect_to topics_path, notice: 'Topic was successfully updated.' }"
   end
 
-  step "Change the topics index view" do
-    message "Open `app/views/topics/index.html.erb` and add the following line:"
-
-    source_code :ruby, '<p id="notice"><%= notice %></p>'
-
-    message <<-MARKDOWN
-    Adding this line will ensure that the `notice` message we included
-    in the `TopicsController` will show up in your `index` view.
-    You can add this line wherever you want the messages to show up on the
-    page. Experiment with adding it in different places in your `index` view.
-    MARKDOWN
-  end
-
   step "Confirm your changes" do
     message "Look at <http://localhost:3000>."
   end


### PR DESCRIPTION
**Step 2: Change the topics index view** of [Redirect To The Topics List After Creating A New Topic](https://docs.railsbridge.org/intro-to-rails/redirect_to_the_topics_list_after_creating_a_new_topic) asks the student to add `<p id="notice"><%= notice %></p>`, but this is already there on L1! It's added by `rails generate scaffold topic title:string description:text`.

We could remove this step to avoid confusion.