### PR TITLE
Add activities

### DIFF
--- a/sites/en/workshop/activities.md
+++ b/sites/en/workshop/activities.md
@@ -1,0 +1,123 @@
+These activities are mostly taken from [Sharon Bowman](http://bowperson.com/)'s excellent books: [The Ten-Minute Trainer](http://www.amazon.com/Ten-Minute-Trainer-Teach-Quick-Stick/dp/0787974420/) and [Training From the Back of the Room](http://www.amazon.com/Training-Back-Room-Aside-Learn/dp/0787996629/). For each activity, **print out instructions and put them up on a wall**. These are ideas and options: don't try and do them all! :)
+
+# <a name="warm-upexercises"></a> Warm-up exercises (a week before the workshop)
+
+## <a name="whatyouknowandwhatsyourplan"></a> What you know, and what’s your plan
+
+Send students an email, asking
+
+* What are three things you already know about programming? (Small things or big things! Who does it? What can you make? Why do people write software?)
+* What do you plan to do with what you learn?
+
+# <a name="justbeforetheworkshopbegins"></a> Just before the workshop begins
+
+## <a name="shareyouranswers"></a> Share your answers
+
+* Grab a pen and sticky notes.
+* Find three other people and ask them about their answers to the warm-up questions.
+* Write them down and stick them up on the wall.
+
+## <a name="whatdoesadeveloperlooklike"></a> What does a developer look like?
+
+* Grab a pen and sticky notes.
+* Write down answers to: "What does a developer look like?"
+* Take a card from the table and find out the answer.
+* Compare your earlier answers to the person you found on the internet.
+
+The cards are clues to finding developers (e.g. who wrote "Designing for Performance"). The answers are developers who are from groups of people that are underrepresented in tech.
+
+## <a name="whatdoesanengineerlooklike"></a> What does an engineer look like?
+
+* Grab a pen and sticky notes.
+* Write down answers to: "What does an a engineer look like?"
+* Look up #ILookLikeAnEngineer and find an awesome person there.
+* Introduce them (and yourself!) to someone else in the room.
+
+## <a name="whatmakesagoodwebapp"></a> What makes a good Web App?
+
+* Grab a pen and sticky notes.
+* Write down at least three things that a good web app needs.
+
+## <a name="findyourmatch"></a> Find Your Match
+
+* Take an index card from the table.
+* Find someone with the same card as you.
+* Together, find out what the technical term means.
+* One of the back of one of the cards, write the explanation down, and stick the cards up on the wall for other to read.
+
+The cards have tech terms on them, such as: HTML, CSS, JavaScript, front-end, Ruby, Rails, Model, View, Controller, MVC. Alternate version: cards have just acronyms: HTML, CSS, JS, MVC, DB, SQL.
+
+## <a name="matchitup"></a> Match It Up
+
+* With a partner, grab a deck of index cards.
+* Match up cards with their definitions.
+* Check your answers.
+
+The deck contains:
+
+* Ruby
+* Rails
+* Git
+* Heroku
+* Sublime Text
+* Terminal / Command Prompt
+* Browser
+
+These are in the opening presentation, and students have been using these things during the InstallFest. This activity helps them see how their learning is progressing.
+
+# <a name="duringtheworkshop"></a> During the workshop
+
+## <a name="goodbadchange"></a> Good, bad, change
+
+* Grab a pen and a card.
+* Write down **one good thing**.
+* Give your card to someone and take a card with one good thing on.
+* Write down **one bad thing**.
+* Give your card to someone and take a card with one bad thing on.
+* Write down **one thing you would change**.
+
+This can be for the InstallFest or the workshop in general.
+
+## <a name="passthatcard"></a> Pass That Card
+
+* Grab a pen and a card.
+* Write down **a question you have**.
+* Give your card to someone and take a card with a question on.
+* Write down **an answer to the question on the card**.
+* Give your card to someone and take a card with an answer on.
+* Write down **agree or disagree**.
+
+## <a name="whatthreethings"></a> What Three Things
+
+* Grab a pen and sticky notes.
+* Write down three things you've learned this morning, one per sticky note.
+* Discuss them with a partner.
+
+## <a name="takeastand"></a> Take A Stand
+
+* Stand on a line from not so confident to very confident.
+* Pair up with someone from the other end of the line and discuss any problems you've had, and get ideas for solutions.
+
+## <a name="threethingsaboutrubyorrails"></a> Three things about Ruby or Rails
+
+* Grab a pen and sticky notes.
+* Write down one thing that you can do now.
+* Write down one thing you're still unsure about.
+* Write down one thing you'd like to learn.
+
+# <a name="endingtheworkshop"></a> Ending the workshop
+
+## <a name="heybuddy"></a> Hey, buddy
+
+* Grab a pen and a card.
+* Write down a SMART goal on the front of a card.
+* Write down your name and email address on the back of a card.
+* Swap cards with a buddy, and agree to email each other during the next week.
+
+A SMART goal is **Specific**, **Measurable**, **Attainable**, **Relevant**, **Time-bound**.
+
+## <a name="valuable"></a> Valuable
+
+* Grab a pen and a card.
+* On your own, write down the most valuable thing you've learned today.
+* In groups of 3 or more, discuss your cards.

--- a/sites/en/workshop/workshop.md
+++ b/sites/en/workshop/workshop.md
@@ -4,6 +4,7 @@
 * [Ruby for Beginners](ruby_for_beginners)
 * [Ruby for Programmers](ruby_for_programmers)
 * [Diagrams (Git, MVC, REST)  ](diagrams)
+* [Activities](activities)
 
 ### Teacher Training
 * [Teacher Training Deck](more_teacher_training)


### PR DESCRIPTION
Over on the RailsBridge Cape Town website repo, @lilliealbert [asked if we would be interested](https://github.com/RailsBridge-CapeTown/rails-bridge-capetown.github.com/issues/35) in getting our [activities page](https://railsbridgecapetown.org/activities.html) into the main docs. We are! Please!

This PR adds this page, with convenient anchors for linking directly to an activity.

What do y'all think? :)