### PR TITLE
Fix link in message board site

### DIFF
--- a/sites/en/message-board/make_a_posts_index_page.step
+++ b/sites/en/message-board/make_a_posts_index_page.step
@@ -15,7 +15,7 @@ end
 
 tools_and_references do
 message <<-MARKDOWN
-* RailsGuides - Listing All Posts: http://guides.rubyonrails.org/getting_started.html#listing-all-posts
+* RailsGuides - Listing All Posts: http://guides.rubyonrails.org/v4.0/getting_started.html#listing-all-posts
   * Feel free to disregard the JSON stuff on this page, if you're so inclined.
 * Bootstrap - Style that table! http://getbootstrap.com/css/#tables
 MARKDOWN


### PR DESCRIPTION
Listing all posts documentation only exists up to Rails 4.0 docs. The newer docs refer to Article as the model.