### PR TITLE
Fixed word == nil comparison example

### DIFF
--- a/sites/en/ruby/nil.step
+++ b/sites/en/ruby/nil.step
@@ -69,7 +69,7 @@ word.nil?
 word = nil
 word.nil?
 # Remember, two equals signs asks if something is equal
-word == nil?
+word == nil
 IRB
 
     message "What's going on here?"


### PR DESCRIPTION
This caused me a bit of confusion during the RailsBridge session.