### PR TITLE
Typo in the Further Reading section of Ruby/Booleans step

### DIFF
--- a/sites/en/ruby/booleans.step
+++ b/sites/en/ruby/booleans.step
@@ -109,9 +109,8 @@ explanation do
 end
 
 further_reading do
-    message "Some languages offer wiggle room about what evaluates to true or false. Ruby has very little. See [What's Truthy and Falsey in Ruby?](https://gist.github.com/jfarmer/2647362)"
-    message "[What's Truthy and Falsey in Ruby?](https://gist.github.com/jfarmer/2647362) has a more detailed walkthrough of booleans."
-    message "Ruby documentation for [true](http://ruby-doc.org/core-2.2.0/TrueClass.html) and [false]](http://ruby-doc.org/core-2.2.0/TrueClass.html)"
+    message "Some languages offer wiggle room about what evaluates to true or false. Ruby has very little. See [What's Truthy and Falsey in Ruby?](https://gist.github.com/jfarmer/2647362) for a more detailed walkthrough of booleans."
+    message "Ruby documentation for [true](http://ruby-doc.org/core-2.2.0/TrueClass.html) and [false](http://ruby-doc.org/core-2.2.0/FalseClass.html)"
 end
 
 next_step "conditionals"


### PR DESCRIPTION
Changes:

- fixed typo in the link to the Ruby docs.
- combined the first 2 sentences in Further Reading to remove duplication and make it
cleaner.

Cheers.