### PR TITLE
Explicitly install rails 4.2.6

### DIFF
--- a/sites/en/installfest/get_a_sticker.step
+++ b/sites/en/installfest/get_a_sticker.step
@@ -24,7 +24,7 @@ step "Have a volunteer check your tool versions" do
     console "rails -v"
     fuzzy_result "Rails 4.2{FUZZY}.x{/FUZZY}"
 
-    tip 'The RailsBridge curriculum is written for Rails 4, so if you still have Rails 3.x, you need to install Rails 4 with `gem install rails`.'
+    tip 'The RailsBridge curriculum is written for Rails 4, so if you still have Rails 3.x, you need to install Rails 4 with `gem install rails -v 4.2.6`.'
   end
 end
 

--- a/sites/en/installfest/linux.step
+++ b/sites/en/installfest/linux.step
@@ -74,7 +74,7 @@ end
 step "Install Rails" do
   message "Using a terminal again, execute the following command to install rails."
 
-  console "gem install rails"
+  console "gem install rails -v 4.2.6"
 end
 
 step "Sublime Text 2" do

--- a/sites/en/installfest/osx_rvm.step
+++ b/sites/en/installfest/osx_rvm.step
@@ -46,7 +46,7 @@ step "Install Ruby" do
 end
 
 step "Install Rails" do
-  console "gem install rails"
+  console "gem install rails -v 4.2.6"
   verify do
     console "rails -v"
     fuzzy_result "Rails 4.{FUZZY}2.x{/FUZZY}"

--- a/sites/en/installfest/windows.step
+++ b/sites/en/installfest/windows.step
@@ -135,7 +135,7 @@ end
 step "Update Rails" do
   message "Currently, RailsInstaller installs Rails 4.1.x, but we want the latest. Upgrading Rails is pretty easy:"
 
-  console "gem install rails --no-ri --no-rdoc"
+  console "gem install rails -v 4.2.6 --no-ri --no-rdoc"
 
   message "...and you're done. New Rails! Woo."
 end


### PR DESCRIPTION
Now that rails 5 is out, `gem install rails` will install rails 5, which may not work with some of the instructions in the guide.