### PR TITLE
Updating copy to reflect GitHub's changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ maintainers to love you. :heart:*
 - If you have an existing fork, please make sure it's up to date.
   It just makes your life easier! If not, make sure you fork *before* cloning,
   otherwise you'll need to spend some time juggling remotes.
-  Look at the section "Pull in upstream changes" in GitHub's
+  Look at the section "Keep your fork synced" in GitHub's
   [Fork A Repo](https://help.github.com/articles/fork-a-repo) article.
 
 - Create a local topic branch before you start working. This branch is going to
@@ -75,7 +75,7 @@ to be a lot of information, but you're :sparkles:awesome:sparkles:! So you'll
 be fine.
 
 First, you'll need a GitHub account, which is totally free. You can sign up
-[here](https://github.com/signup/free).
+[here](https://github.com/join).
 
 Next, browse the [GitHub Help site](https://help.github.com) and the
 [GitHub Guides](https://guides.github.com/). The Help Site is more technical, and the

--- a/sites/en/installfest/create_a_github_account.step
+++ b/sites/en/installfest/create_a_github_account.step
@@ -41,13 +41,13 @@ step "Set up SSH authentication with GitHub" do
 
   h1 "Add your SSH key to GitHub"
 
-  message "Navigate to github.com and make sure you are logged in. On any page on the GitHub site, click the black gear icon in the top right corner. This will take you to the account settings page."
+  message "Navigate to github.com and make sure you are logged in. On any page on the GitHub site, click your profile photo in the top right corner to the right of the plus sign. In the dropdown menu, click **Settings** to go to the account settings page."
 
-  message "On the account setting page, select **SSH Keys** from the column on the left."
+  message "On the account settings page, select **SSH and GPG keys** from the column on the left."
 
-  message "At the top right of this page, click the button that says **Add SSH key**. In the title field, give a name for your SSH key, you might call it **My PC** or **Personal MacBook**. In the key field, paste the key you copied."
+  message "At the top right of this page, click the button that says **New SSH key**. In the title field, give a name for your SSH key, you might call it **My PC** or **Personal MacBook**. In the key field, paste the key you copied."
 
-  message "Click **Add Key**"
+  message "Click **Add SSH key**"
 
   message "Confirm the action by providing your GitHub Password"
 end


### PR DESCRIPTION
GitHub has changed some things since the last time we visited the Installfest step "Create a GitHub account." I've edited some copy to reflect GitHub's current UI in order to clarify a few actions.

I've also made similar copy changes in CONTRIBUTING.md, wherein GitHub changed the title of a guide section as well as the link to create a new account.

Cheers!