### PR TITLE
Added `gem install bundler` within the instructions

### DIFF
--- a/sites/en/installfest/deploy_a_rails_app.step
+++ b/sites/en/installfest/deploy_a_rails_app.step
@@ -87,6 +87,7 @@ step "Deploy your app to Heroku" do
     end
 
     console <<-BASH
+gem install bundler
 bundle install --without production
     BASH
 


### PR DESCRIPTION
Recently at RailsBridge Tulsa's first class we ran into an issue where
bundler was not installed. The students on had to first run `gem
install bundler` in order to run `bundle install --without production`.
This addition should help prevent problems in the future.