### PR TITLE
clarify bundle install command

### DIFF
--- a/sites/en/intro-to-rails/_deploying_to_heroku.step
+++ b/sites/en/intro-to-rails/_deploying_to_heroku.step
@@ -30,6 +30,7 @@ end
 step "Apply the Gemfile changes" do
   console "bundle install --without production"
   message "Every time the `Gemfile` changes, you need to run ``bundle install`` for the changes to be processed. The processed version of the changes is stored in another file called ``Gemfile.lock``."
+  message "Here we are bundling without the gems in the group ``production``."
 end
 
 step "Commit the Gemfile changes" do


### PR DESCRIPTION
clarify what `bundle install --without production` means; it means we are bundling without the gems in the group `production`.