### PR TITLE
Fixes Step 9 instructions in 'Intro to Ruby' Commandline block

### DIFF
--- a/sites/en/ruby/command_line.step
+++ b/sites/en/ruby/command_line.step
@@ -103,6 +103,7 @@ step do
     console <<-LINES
 cd ~
 ls
+cd workspace
 cd rai
     LINES
     message '... and hit `TAB`.'


### PR DESCRIPTION
### SUMMARY: 
- In Step 4 of the Commandline section,  we instruct students to put the `railsbridge_ruby` dir under `workspace/`, rather than  `~`. 
- In Step 9, we instruct students to try and find `railsbridge_ruby` under `~` but we should actually have them looking under `workspace`. 

The steps should be:
```
cd ~
ls
cd workspace
cd rai
```