### PR TITLE
Adds an "Update RubyGems" step (again)

### DIFF
--- a/sites/en/installfest/windows.step
+++ b/sites/en/installfest/windows.step
@@ -82,6 +82,40 @@ step "Open a Terminal" do
   end
 end
 
+step "Update RubyGems" do
+  message "The version of RubyGems that comes with RailsInstaller has some problems. Follow these steps to upgrade it!"
+
+  step "Check to see if you need to update" do
+    console "gem -v"
+
+    message "If the output is **2.6.6** or earlier, keep following the instructions."
+
+    message "If the output is **2.6.7** or later, <a href='#install-node'>skip to the next step!</a>"
+  end
+
+  step "Download the update" do
+    message "Visit https://rubygems.org/downloads/rubygems-update-2.6.7.gem"
+
+    message "**Right click -> Save target as...** the file **rubygems-update-2.6.7.gem** to your **C:\\Sites** directory"
+  end
+
+  step "Install the update" do
+    message "Back at the command prompt, run the following commands:"
+
+    console_without_message "gem install --local C:\\Sites\\rubygems-update-2.6.7.gem"
+
+    console_without_message "update_rubygems --no-document"
+
+    message "**Close and reopen your command prompt**, then verify you have the upgraded RubyGems by typing this in the terminal:"
+
+    console_without_message "gem -v"
+    result "2.6.7"
+
+    message "Finally, you can clean up by running the following command:"
+    console_without_message "gem uninstall rubygems-update -x"
+  end
+end
+
 a name: 'install-node'
 step "Install Node.js" do
 


### PR DESCRIPTION
RubyGems has changed [the handling of SSL certificates for the gem server](hhttp://guides.rubygems.org/ssl-certificate-update/#background). The version of RubyGems that ships with RailsInstaller (which is 2.4.x) doesn't have the updated CA certificates, and is also broken. This means that after installing ruby and rubygems, you cannot `gem install` anything.

This commit adds some notes on how to fix this, based on [similar notes that were added last year](https://github.com/railsbridge/docs/commit/fdbc3b40c02af253dab8f723f8bfc435f43b0ed1) as well as [this RubyGems guide](http://guides.rubygems.org/ssl-certificate-update/#installing-using-update-packages).

Fixes https://github.com/railsbridge/docs/issues/587