### PR TITLE
Updates the expected version of Node

### DIFF
--- a/sites/en/installfest/windows.step
+++ b/sites/en/installfest/windows.step
@@ -94,7 +94,7 @@ step "Install Node.js" do
   message "Once your computer is back up, load **Command Prompt with Ruby and Rails** and..."
 
   console "node -v"
-  fuzzy_result "v4{FUZZY}.x.x{/FUZZY}"
+  fuzzy_result "v6{FUZZY}.x.x{/FUZZY}"
 end
 
 step "Update Rails" do


### PR DESCRIPTION
The current LTS release is 6.9.1, so let's updated the guide to be less confusing. There's probably a better way to keep track of this rather than trailing the leading version of Node all the time, but this is a good first step :->