### PR TITLE
Add credits to a few curricula

### DIFF
--- a/sites/en/javascript-snake-game/lesson-14.step
+++ b/sites/en/javascript-snake-game/lesson-14.step
@@ -1,1 +1,10 @@
 insert '../javascript-to-do-list/_deploying_your_site'
+
+message <<-MARKDOWN
+# Credits
+
+This curriculum was originally written by
+[Zassmin Montes de Oca](http://zassmin.com/) and
+[Zee Spencer](http://www.zeespencer.com/),
+and has been improved by all sorts of [lovely RailsBridge volunteers](https://github.com/railsbridge/docs/commits/master/sites/en/javascript-snake-game).
+MARKDOWN

--- a/sites/en/javascript-to-do-list-with-react/next_steps.step
+++ b/sites/en/javascript-to-do-list-with-react/next_steps.step
@@ -20,3 +20,11 @@ ul do
     a "http://railsbridge.org/learn/resources", href: "http://railsbridge.org/learn/resources"
   end
 end
+
+message <<-MARKDOWN
+# Credits
+
+This curriculum was originally written by
+[Srinivas Rao](https://twitter.com/raorao_)
+and has been improved by all sorts of [lovely RailsBridge volunteers](https://github.com/railsbridge/docs/commits/master/sites/en/javascript-to-do-list-with-react).
+MARKDOWN

--- a/sites/en/javascript-to-do-list/next_steps.step
+++ b/sites/en/javascript-to-do-list/next_steps.step
@@ -20,3 +20,11 @@ ul do
     a "http://railsbridge.org/learn/resources", href: "http://railsbridge.org/learn/resources"
   end
 end
+
+message <<-MARKDOWN
+# Credits
+
+This curriculum was originally written by
+[Srinivas Rao](https://twitter.com/raorao_)
+and has been improved by all sorts of [lovely RailsBridge volunteers](https://github.com/railsbridge/docs/commits/master/sites/en/javascript-to-do-list).
+MARKDOWN

--- a/sites/en/job-board/add_more_things.step
+++ b/sites/en/job-board/add_more_things.step
@@ -15,4 +15,8 @@ message <<-MARKDOWN
   * Add a user model and auth with Devise
   * Test it! Write a controller spec.
 
+  ## Credits
+
+  This curriculum was originally written by [Lillie Chilen](http://www.twitter.com/lilliealbert)
+  and has been improved by all sorts of [lovely RailsBridge volunteers](https://github.com/railsbridge/docs/commits/master/sites/en/job-board).
 MARKDOWN

--- a/sites/en/learn-to-code/next_steps.md
+++ b/sites/en/learn-to-code/next_steps.md
@@ -14,6 +14,8 @@
 
 # Thanks
 
-* to all the TAs
+* to all the TAs!
 * to all the students!
+* to [Alex Chaffee](http://alexchaffee.com/), the original author of this curriculum, and
+* to all the [RailsBridge volunteers](https://github.com/railsbridge/docs/commits/master/sites/en/learn-to-code) who have helped make it better!
 

--- a/sites/en/message-board/add_other_features_of_your_choosing.step
+++ b/sites/en/message-board/add_other_features_of_your_choosing.step
@@ -13,4 +13,11 @@ Suggestions:
 * Deploy to Heroku and send your message board to all your friends!
 
 ## ...and that's that! Good luck! Make more things! Come back again!
+
+# Credits
+
+This curriculum was originally written by
+[Lillie Chilen](http://www.twitter.com/lilliealbert) and
+[Travis Grathwell](https://github.com/tjgrathwell),
+and has been improved by all sorts of [lovely RailsBridge volunteers](https://github.com/railsbridge/docs/commits/master/sites/en/message-board).
 MARKDOWN


### PR DESCRIPTION
I think we don't give people enough direct credit for their work on RailsBridge, and one easy place to rectify that is in the docs! So I've added credits where I could tell (or know) who to give credit to.

This commit adds a note to the last page of a few curriculums with the name(s) of the original author(s) and a link to the history of the curriculum on GitHub so that curious people can see who has contributed specifically to this curriculum.

(I'm using the directory history instead of the contribution graph because the contribution graph can't be
broken down by what part of the codebase the contribution was made to, as far as I can tell.)

The history of the Suggestotron curriculum happened enough outside of git histories that I think it makes sense to leave it with the generic link to the contributor graph. The Ruby curriculum could probably use credit, but I'm not totally sure who it goes to, Travis maybe?