### PR TITLE
Installfest: show a recent version of Homebrew

### DIFF
--- a/sites/en/installfest/_install_homebrew.step
+++ b/sites/en/installfest/_install_homebrew.step
@@ -7,5 +7,8 @@ important "If that doesn't work, visit <https://github.com/Homebrew/homebrew/wik
 
 verify do
   console "brew -v"
-  fuzzy_result "Homebrew 0.9{FUZZY}.5{/FUZZY}"
+  fuzzy_result <<-TEXT
+    Homebrew 1{FUZZY}.1.13-19-g55c02ae77
+    Homebrew/homebrew-core (git revision 4075; last commit 2017-04-18){/FUZZY}
+  TEXT
 end


### PR DESCRIPTION
A few people at the installfest last night were confused by this, because installing Homebrew from scratch installs version 1.1 and they were afraid they had a bad version.