### PR TITLE
Use only one-line commands in installfest

### DIFF
--- a/sites/en/installfest/_install_ruby.step
+++ b/sites/en/installfest/_install_ruby.step
@@ -3,10 +3,8 @@ console <<-BASH
 BASH
 
 message "This downloads and compiles Ruby, which takes a while."
-console <<-BASH
-  rvm use #{version_string(:ruby_short)}
-  rvm --default use #{version_string(:ruby_short)}
-BASH
+console "rvm use #{version_string(:ruby_short)}"
+console "rvm --default use #{version_string(:ruby_short)}"
 
 verify do
   console "ruby -v"
@@ -29,4 +27,3 @@ div do
     message "Once that completes, retry `rvm install #{version_string(:ruby_short)}`"
   end
 end
-

--- a/sites/en/installfest/configure_git.step
+++ b/sites/en/installfest/configure_git.step
@@ -1,9 +1,9 @@
 message "(If you used RailsInstaller on Windows then you should already have `user.name` and `user.email` configured.)"
 
-console <<-BASH
-git config --global user.name "Your Actual Name"
-git config --global user.email "Your Actual Email"
-BASH
+message "In the next commands, don't copy-paste the whole thing. Use the name and email address you usually use. Don't use a username (like your github username)."
+
+console 'git config --global user.name "Your Actual Name, In Quotes"'
+console 'git config --global user.email "Your Actual Email, In Quotes"'
 
 important "Use the same email address for heroku, git, github, and ssh."
 
@@ -25,4 +25,3 @@ git config --global color.ui auto
 end
 
 next_step "create_an_ssh_key"
-

--- a/sites/en/installfest/deploy_a_rails_app.step
+++ b/sites/en/installfest/deploy_a_rails_app.step
@@ -117,10 +117,8 @@ step "Deploy your app to Heroku" do
 
     message "Before running the following command (to add to your local git repository), make sure that you are in the `test_app` directory."
 
-    console <<-BASH
-      git add .
-      git commit -m "Updates for heroku deployment"
-    BASH
+    console 'git add .'
+    console 'git commit -m "Updates for heroku deployment"'
   end
 
   step "Deploy (push) to heroku" do
@@ -185,4 +183,3 @@ step "Deploy your app to Heroku" do
 end
 
 next_step "get_a_sticker"
-


### PR DESCRIPTION
A few students copy-pasted the 2-line commands and got a little confused because the first line executed and the second line just sat there.

Instead, provide only one-line commands in the installfest.

I also added some guidance around the "Your Actual Name"/"Your Actual Email" parts of the git configuration; that's not as relevant to this PR 