### PR TITLE
Fixes Issue #615: Function naming mismatch

### DIFF
--- a/sites/en/javascript-snake-game/lesson-10.step
+++ b/sites/en/javascript-snake-game/lesson-10.step
@@ -5,7 +5,7 @@ markdown <<-MARKDOWN
   segment further forward in snake to the current segment when it moves. This way
   all segments follow the same path!
 
-  Let's define a new function called `segmentFurtherDown` which takes a
+  Let's define a new function called `segmentFurtherForwardThan` which takes a
   segment index and a snake and returns the segment closer to the head. Let's
   start with:
 

--- a/sites/en/ruby/command_line.step
+++ b/sites/en/ruby/command_line.step
@@ -103,6 +103,7 @@ step do
     console <<-LINES
 cd ~
 ls
+cd workspace
 cd rai
     LINES
     message '... and hit `TAB`.'


### PR DESCRIPTION
### SUMMARY:
Fixes https://github.com/railsbridge/docs/issues/615 by renaming misnamed function reference in code explanation. 