### PR TITLE
Removes double the typos

### DIFF
--- a/sites/en/intro-to-rails/rails_architecture.step
+++ b/sites/en/intro-to-rails/rails_architecture.step
@@ -22,8 +22,8 @@ explanation {
 
   h3 "Model"
   message <<-MARKDOWN
-* For all the Models we create in RailsBridge, Model objects have a corresponding record in the the database. The name of the table in the database is the plural version of the Model's class name. For example, if the Model is called 'Duck', it will automatically query or write to the 'ducks' table in the database.
-* Methods internal to Rails make it easy to automatically write records to the the database and query the database to get the records again later.
+* For all the Models we create in RailsBridge, Model objects have a corresponding record in the database. The name of the table in the database is the plural version of the Model's class name. For example, if the Model is called 'Duck', it will automatically query or write to the 'ducks' table in the database.
+* Methods internal to Rails make it easy to automatically write records to the database and query the database to get the records again later.
 * The Model is a bridge between the database and your application's code.
   MARKDOWN
 

--- a/sites/en/job-board/create_a_rails_app.step
+++ b/sites/en/job-board/create_a_rails_app.step
@@ -41,7 +41,7 @@ message <<-MARKDOWN
   (You must have at least one window open, so if that option is greyed out, open a window with cmd+n (Mac) or ctl+n (PC))
 MARKDOWN
 
-discussion_box "Text Editor vs Command Line", "Review the differences between the the command line and your text editor, even if everyone already knows!"
+discussion_box "Text Editor vs Command Line", "Review the differences between the command line and your text editor, even if everyone already knows!"
 
 message "# Let's Talk About Dependencies"
 

--- a/sites/en/job-board/store_jobs_in_the_database.step
+++ b/sites/en/job-board/store_jobs_in_the_database.step
@@ -48,7 +48,7 @@ RUBY
 message <<-MARKDOWN
   Running this code will make a table in our database called jobs. Right now it just has the timestamps (`created_at` and `updated_at`). What else should a job have? Let's start with a title and description.
 
-  Add the the title and description so it looks like this:
+  Add the title and description so it looks like this:
 MARKDOWN
 
 source_code :ruby, <<-RUBY

--- a/sites/en/workshop/noobie-outline.txt
+++ b/sites/en/workshop/noobie-outline.txt
@@ -1,4 +1,4 @@
-RailsBridge Introductory Curriculum for Non-Programmers 
+RailsBridge Introductory Curriculum for Non-Programmers
 
 Target Audience: Students who have not exposure to the command line and/or programming (and may be fuzzy on how the file system works)
 
@@ -14,12 +14,12 @@ File Directories:
 Use house / rooms / drawers metaphor for how directories store files and keep everything in your ‘house’ organized.
 Review ./ and ~/ references to self and root directories. Explain where home and root are located in relation to all directories.
 Explain difference between absolute paths (starting with a /) and relative paths.
-.. is the relative path the the parent directory.
+.. is the relative path the parent directory.
 Command Line Basics:: pwd, ls, cd, touch, mv, cp, rm, .. (parent directory)
 Text Editing:
 Explain differences between text editor vs. word processor.
 Have group open editor, create and save file with explanation of how and where files are stored.
-Explain file extensions and file types. File types tell the editor how to color the special words in each language. 
+Explain file extensions and file types. File types tell the editor how to color the special words in each language.
 Explain difference between the buffer (in the editor’s memory) and the file (stored on disk).  Emphasize the importance of saving the buffer to a file before trying to run it with ruby.
 Compilers, Interpreters and Programming Languages:
 Use metaphor of programming language as an agreed set of rules about syntax for writing source code that is sent to the interpreter and translated into byte code.
@@ -44,10 +44,10 @@ Explain ‘method calls’.
 Explain to group the important of strings and review string operations. Have group work with strings in IRB.
 IRB Console:
 Have group open IRB console and create objects, method calls and variable assignments.
-Tie in lecture above on Objects, Methods, Variables with exercises in IRB that allow students to see results line-by-line. 
+Tie in lecture above on Objects, Methods, Variables with exercises in IRB that allow students to see results line-by-line.
 Have group query classes for their methods in IRB.
 HTTP:
 Lead group exercise in using telnet to query Wikipedia, make GET request and view response in command line, then compare to view source of same page in browser.
 Sinatra Application
-Lead group exercise in writing Sinatra application and run it locally. “Hello, Web!”  
+Lead group exercise in writing Sinatra application and run it locally. “Hello, Web!”
 Extend to add “the time is Sun Mar 27 09:44:09 PDT 2011” using `date`.


### PR DESCRIPTION
Noticed that there were a couple of double `the`s in the docs. This PR simply replaces them with a single `the`