### PR TITLE
Testing curriculum fixes

### DIFF
--- a/sites/en/testing-rails-applications/additional_concepts.step
+++ b/sites/en/testing-rails-applications/additional_concepts.step
@@ -25,6 +25,7 @@ message <<-MARKDOWN
   ```ruby
   orange = spy('orange')
   orange.name
+  expect(orange).to receive(:name)
   orange.name
   expect(orange).to receive(:name).exactly(2).times
   ```

--- a/sites/en/testing-rails-applications/additional_concepts.step
+++ b/sites/en/testing-rails-applications/additional_concepts.step
@@ -19,13 +19,14 @@ message <<-MARKDOWN
   So, when you write a test that calls the title attribute of the orange double, you'll always get back the string Florida Orange. Got it? Good!
 
   ### Spies
-  With spies, we are not talking about espionage... at least, not in relation to testing :) Spies can be used to verify whether a method was called on an object.
+  With spies, we are not talking about espionage... at least, not in relation to testing :) Spies can be used to verify whether a method was called on an object a certain number of times.
   For instance (assume you already have the orange double from above):
 
   ```ruby
   orange = spy('orange')
   orange.name
-  expect(orange).to have_received(:name)
+  orange.name
+  expect(orange).to receive(:name).exactly(2).times
   ```
 
   Obviously, this is a simplified case. Instead of orange.name, you might have a complicated method that executes many functions internally and that's where spies can come in handy; they can check easily whether one specific method was called. Capiche? Ok, let's keep on trucking!

--- a/sites/en/testing-rails-applications/testing_frameworks.step
+++ b/sites/en/testing-rails-applications/testing_frameworks.step
@@ -85,7 +85,7 @@ expected: #< Tree @age=1 >
 </div>
 
 ## Matchers
-Remember our example in the RSpec Basics section above? The 'to eq' is a matcher! RSpec has many built-in matchers. Matchers evaluates our expectations. In our example, we are saying that we expect orange_tree's age to equal an integer of 1.
+Remember our example in the RSpec Basics section above? The 'to eq' is a matcher! RSpec has many built-in matchers. You can think of them as ways to equate or check certain values or expressions to what you think or expect they would "match" to. In our example, we are saying that we expect orange_tree's age to equal an integer of 1.
 
 Check out the other built-in matchers!
 https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/sites/en/testing-rails-applications/testing_frameworks.step
+++ b/sites/en/testing-rails-applications/testing_frameworks.step
@@ -39,14 +39,7 @@ rails generate rspec:install
 </pre>
 </div>
 
-This adds the following files which are used for configuration:
-
-<div class="console"><pre>
-.rspec
-spec/spec_helper.rb
-spec/rails_helper.rb
-</pre>
-</div>
+This command will add the spec helper, rails helper, and .rspec configuration files.
 
 Use the rspec command to run your specs:
 
@@ -92,7 +85,7 @@ expected: #< Tree @age=1 >
 </div>
 
 ## Matchers
-Remember in our example on line 5? 'to eq' is a matcher. RSpec has many built-in matchers. Matchers evaluates our expectations. In our example, we are saying that we expect orange_tree's age to equal an integer of 1.
+Remember our example in the RSpec Basics section above? The 'to eq' is a matcher! RSpec has many built-in matchers. Matchers evaluates our expectations. In our example, we are saying that we expect orange_tree's age to equal an integer of 1.
 
 Check out the other built-in matchers!
 https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/sites/en/testing-rails-applications/types_of_tests.step
+++ b/sites/en/testing-rails-applications/types_of_tests.step
@@ -27,7 +27,7 @@ steps do
     source_code :ruby, <<-RUBY
       RSpec.describe Orange, :type => :model do
         context 'ActiveRecord associations' do
-          it 'Orange belongs to tree' do
+          it 'belongs to tree' do
             expect(Orange.reflect_on_association(:tree).macro).to be (:belongs_to)
           end
         end
@@ -47,7 +47,7 @@ steps do
 
   step do
 
-    message "Now let's write a has_many association test for the relationship between the Tree model and the Orange model! (hint: this doesn't exist yet so you'll have to create the model and migrate!)"
+    message "Now let's write a has_many association test for the relationship between the Tree model and the Orange model! (<strong>hint: this doesn't exist yet so you'll have to create the model and migrate!</strong>)"
 
     message "On to controller tests! Just like the Orange model, you will create the OrangesController, which will also create spec files in the /spec/controllers folder of your app."
   end
@@ -71,7 +71,7 @@ steps do
             get :index
             expect(response).to render_template("index")
           end
-  
+
           it "renders html" do
             process :index, method: :get
             expect(response.content_type).to eq "text/html"
@@ -80,13 +80,13 @@ steps do
       end
     RUBY
 
-    message "You should see two failing tests. You'll need to add a route, index action, and a view. Not sure where to start? Read the errors in your failing tests for a hint. Run 'bundle exec rspec' after each change until both tests pass."
+    message "You should see two failing tests. <strong>Hint: You'll need to add a route, index action, and a view.</strong> Not sure where to start? Read the errors in your failing tests for a hint. Run 'bundle exec rspec' after each change until both tests pass."
 
     message "Note: as you write the controller tests, you may be prompted to install a missing gem called 'rails-controller-testing' to use the assert_template method. If prompted, please add it to your Gemfile and do a bundle install!"
   end
 
   step do
-    message "Now, write another controller test for the new action (hint: you might need to look up what a mock is)."
+    message "Now, write another controller test for the new action (<strong>hint: you might need to look up what a mock is</strong>)."
   end
 
   step do
@@ -109,14 +109,15 @@ steps do
 
     message "First, create a views folder in the spec folder. Then, create an oranges folder in the views folder. Lastly, create an oranges view spec file in the oranges folder. Type these commands in the terminal:"
 
-    console_without_message "mkdir app/spec/views"
-    console_without_message "mkdir app/spec/views/oranges"
-    console_without_message "cd app/spec/views/oranges"
+    console_without_message "mkdir spec/views"
+    console_without_message "mkdir spec/views/oranges"
+    console_without_message "cd spec/views/oranges"
     console_without_message "touch show.html.erb_spec.rb"
   end
   step do
-    message "Then, run rspec."
+    message "Change directory back to the root directory of your app. Then, run rspec."
 
+    console_without_message "cd ../../.."
     console_without_message "bundle exec rspec"
 
     message "You should see a report with some passing tests but those are just the model and controller tests you wrote. So, let's add some view tests!"


### PR DESCRIPTION
@schaui6 @camillevilla 

There were minor hiccups (items in console boxes that didn't need to be typed out, naming of tests, bolding hints that were missed, directory paths, test clarity) when we did this curriculum at the recent RailsBridge in SF. This PR addresses the minor hiccups (not sure why it's picking up so many changes... it's just the first 3 files after the Gemfile that I changed).