### PR TITLE
update installfest/intro to install a version of pg that works with rails 5.1.4

### DIFF
--- a/sites/en/installfest/deploy_a_rails_app.step
+++ b/sites/en/installfest/deploy_a_rails_app.step
@@ -72,7 +72,7 @@ step "Deploy your app to Heroku" do
       end
 
       group :production do
-        gem 'pg'
+        gem 'pg', '~> 0.18'
       end
     RUBY
 

--- a/sites/en/intro-to-rails/_deploying_to_heroku.step
+++ b/sites/en/intro-to-rails/_deploying_to_heroku.step
@@ -22,7 +22,7 @@ group :development, :test do
 end
 
 group :production do
-  gem 'pg'
+  gem 'pg', '~> 0.18'
 end
   RUBY
 end


### PR DESCRIPTION
This fixes this issue below for the installfest docs:
https://stackoverflow.com/questions/48225233/gemloaderror-cant-activate-pg-0-18-already-activated-pg-1-0-0

Came across this at the denver railsbridge install yesterday :)