### PR TITLE
Use less jargon in the installfest opener

### DIFF
--- a/sites/en/installfest/installfest.step
+++ b/sites/en/installfest/installfest.step
@@ -41,18 +41,12 @@ step "Read This Overview" do
 Here's a list of tools you'll be installing. As you go through the workshop, we'll explain what each one is for and how to use it.
 
 * **Ruby**. A programming language.
-* **Rails**. A framework for making web applications with Ruby. It does a lot of the setting up work for you and creates a model-view-controller structure for your web application. We'll go into more detail about that later.
-* **Git**. A revision or source control system. It creates a repository, which is a complete history of your programming changes, so you can undo changes and roll back to previous versions of your work if something has gone wrong.
-* **GitHub**. (optional)
-* **Heroku**. An application server, which hosts your application during development. This allows you to get your application online and interact with it from any browser, instead of just on your local machine.
+* **Rails**. A framework for making web applications with Ruby. It does a lot of the setting up work for you, which is really handy, but we'll cover this in more detail a little later.
+* **Git**. A revision or source control system. It creates a _repository_ (sometimes called a _repo_ for short), which is a complete history of your changes to what you're working on. This means you can undo changes and roll back to previous versions of your work if something has gone wrong.
+* **GitHub** (optional). A place to store your Git repository online, so you can access it from any computer.
+* **Heroku**. An _application server_, which hosts your application while you're working on it. This allows you to access your app online and interact with it from any browser, instead of just on your local computer.
 * **Atom** (or [some other editor](editors)). To write programs in Ruby, you need a text editor to create, edit and save Ruby files.
-* Various useful "**Ruby gems**". Ruby gems are useful bits of Ruby code that someone has created for reuse, so you don't have to write it yourself. Including...
-  * bundler
-  * sqlite
-
-You will also create an account on Heroku, an application hosting platform.
-
-If you already have an account on Heroku, make sure you know your username and password.
+* A couple of useful **Ruby gems**. Ruby gems are useful bits of Ruby code that someone has created for reuse, so you don't have to write it yourself.
 
 If you've already installed the above tools and are confident they are setup correctly, skip ahead to the <a href="get_a_sticker">Get a Sticker</a> step.
 


### PR DESCRIPTION
**This PR:** Cleans up the Installfest opening page a little, by removing some (in my opinion) unnecessary jargon, and using a slightly friendlier tone. I'll comment on the individual changes with my reasoning behind them, so check out the diff below.