### PR TITLE
Fix RailsInstaller link and Heroku CLI confusion

### DIFF
--- a/sites/en/installfest/create_a_heroku_account.step
+++ b/sites/en/installfest/create_a_heroku_account.step
@@ -24,11 +24,11 @@ step "Install the Heroku CLI" do
     console "heroku version"
     fuzzy_result <<-TEXT
       {FUZZY}heroku-toolbelt/3.30.6 (x86_64-darwin10.8.0) ruby/1.9.3{/FUZZY}
-      heroku-cli{FUZZY}/5.6.8-9647e01 (darwin-amd64) go1.7.4{/FUZZY}
+      heroku{FUZZY}/7.6.0 darwin-x64 node-v10.6.0{/FUZZY}
       {FUZZY}You have no installed plugins.{/FUZZY}
     TEXT
   end
-  message "The output could be different, depending on whether this is the first time you've installed the Heroku CLI, but it should always have `heroku-cli` in it."
+  message "The output could be different, depending on whether this is the first time you've installed the Heroku CLI, but it should always have `heroku` in it."
   message "If `heroku version` doesn't work, try the command again in a new terminal window."
 end
 

--- a/sites/en/installfest/windows.step
+++ b/sites/en/installfest/windows.step
@@ -6,7 +6,7 @@ MARKDOWN
 
 step "Run RailsInstaller" do
   message "RailsInstaller includes Rails, Ruby, Git and SQLite."
-  message "Go to <http://railsinstaller.org/>, scroll to the 'Downloads' section, and download the RailsInstaller for Windows/Ruby #{version_string(:ruby_short)}."
+  message "Go to <http://railsinstaller.org/en>, scroll to the 'Downloads' section, and download the RailsInstaller for Windows/Ruby #{version_string(:ruby_short)}."
   message "Click on the downloaded file to run the install wizard.  Click Next at each step to accept the defaults."
   message "Be sure to check the boxes for *Install git (recommended)* and  *Add executables for Ruby, DevKit Git (if checked above) to the PATH*"
 


### PR DESCRIPTION
Hi!

As part of prep for Rails Bridge in Wellington, NZ (http://railsbridge.nz/), we've noticed a few issues that would be good to get fixed on the docs site :)

My fix to the Rails Installer link also fixes https://github.com/railsbridge/docs/issues/640 and https://github.com/railsbridge/docs/issues/637.

Please let me know if there are any issues you want me to fix :)

**`bundle exec rake` result:**
```
Finished in 10.95 seconds (files took 1.44 seconds to load)
291 examples, 0 failures
```