### PR TITLE
Updates to Homebrew installation instructions

### DIFF
--- a/sites/en/installfest/_install_homebrew.step
+++ b/sites/en/installfest/_install_homebrew.step
@@ -1,5 +1,5 @@
 
-console %q{ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"}
+console %q{/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"}
 
 message "You may have to press 'ENTER' when prompted and type in your password."
 

--- a/sites/en/installfest/_install_homebrew.step
+++ b/sites/en/installfest/_install_homebrew.step
@@ -3,7 +3,7 @@ console %q{ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/inst
 
 message "You may have to press 'ENTER' when prompted and type in your password."
 
-important "If that doesn't work, visit <https://github.com/Homebrew/homebrew/wiki/installation> and follow the instructions there."
+important "If that doesn't work, visit <https://docs.brew.sh/Installation> and follow the instructions there."
 
 verify do
   console "brew -v"


### PR DESCRIPTION
The docs link is out of date. I think the proposed link is the best successor. While reviewing I also noticed that homebrew's one-liner specifies the absolute path to system ruby and the Railsbridge docs should probably do so as well.