### PR TITLE
Update ruby_short version string to Heroku minimum

### DIFF
--- a/lib/site_extensions/installfest.rb
+++ b/lib/site_extensions/installfest.rb
@@ -3,7 +3,7 @@ module StepExtensions
     def version_string(name)
       case name
         when :ruby_short
-          '2.3'
+          '2.3.8'
         when :windows_rubygems_min
           '2.6.7'
         when :windows_rubygems_min_short


### PR DESCRIPTION
Participant in upcoming Railsbridge Tulsa event reports unable to use
Heroku with recommended Ruby version of 2.3. Heroku current minimum
version is 2.3.8. We suggested trying latest, and user reports no
problems with 2.5.3.