### PR TITLE
bugfix spanish locale overwriting english

### DIFF
--- a/locales/es/header_sections.yml
+++ b/locales/es/header_sections.yml
@@ -1,4 +1,4 @@
-en:
+es:
   header_section:
     steps: "Pasos"
     explanation: "Explicación"


### PR DESCRIPTION
Fixes a bug where spanish words appear on pages that are ostensibly english locale. See screenshot:

![image](https://github.com/railsbridge/docs/assets/222655/f39c44c7-e8ba-455e-9297-0ca393236f0d)


I filed #702 because that's making it difficult to reproduce in production but usually you would be able to see the problem on [this page](http://docs.railsbridge.org/intro-to-rails/running_your_application_locally) for example