### PR TITLE
Fix GitHub link

### DIFF
--- a/lib/doc_page.rb
+++ b/lib/doc_page.rb
@@ -41,7 +41,7 @@ class DocPage < Html5Page
   end
 
   def git_url
-    "https://github.com/railsbridge/docs/blob/master/sites/#{@locale}/#{site.name}/#{file_name}"
+    "https://github.com/railsbridge/docs/blob/master/sites/#{site.name}/#{file_name}"
   end
 
   def src_url


### PR DESCRIPTION
With the introduction of #687, we don't need the locale anymore